### PR TITLE
Fix Go Report Card badge URL in README

### DIFF
--- a/glx/README.md
+++ b/glx/README.md
@@ -1,6 +1,6 @@
 # GLX - GENEALOGIX CLI Tool
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/genealogix/glx/glx)](https://goreportcard.com/report/github.com/genealogix/glx/glx)
+[![Go Report Card](https://goreportcard.com/badge/github.com/genealogix/glx)](https://goreportcard.com/report/github.com/genealogix/glx)
 [![Coverage](https://img.shields.io/badge/coverage-70.5%25-yellow.svg)](#test-coverage)
 [![Tests](https://img.shields.io/badge/tests-passing-brightgreen.svg)](#running-tests)
 


### PR DESCRIPTION
## Description

Corrects the Go Report Card badge URL in the README to point to the correct repository path, removing the redundant `/glx` suffix from the module path.

## Changes Made

- Updated Go Report Card badge URL from `github.com/genealogix/glx/glx` to `github.com/genealogix/glx` in both the badge and report links

## Testing

No testing needed - this is a documentation-only change to fix a badge URL.

## Review Checklist

- [x] Code follows project conventions
- [x] Documentation updated

## Additional Context

The badge was pointing to an incorrect module path with a duplicate `glx` suffix. This change ensures the badge correctly links to the Go Report Card for the actual module.

https://claude.ai/code/session_0199c3AeuoZZFWqV4DCx8xoK