### PR TITLE
feat: add township place type to standard vocabulary

### DIFF
--- a/specification/5-standard-vocabularies/place-types.glx
+++ b/specification/5-standard-vocabularies/place-types.glx
@@ -28,6 +28,11 @@ place_types:
     description: "Town or village"
     category: "geographic"
 
+  township:
+    label: "Township"
+    description: "Township or civil subdivision of a county (common in U.S. land survey and census records)"
+    category: "administrative"
+
   parish:
     label: "Parish"
     description: "Church parish or ecclesiastical division"


### PR DESCRIPTION
## Summary
Add **township** to the standard place types vocabulary.

## Problem
Township is a common administrative division in U.S. census and land survey records. I encountered this while building a GLX archive from 1860 U.S. Federal Census data — *Marston* is a township in Sauk County, Wisconsin.

Without this type, users must fall back to `town` which is semantically different:
- **Town**: A geographic settlement (city/village)
- **Township**: A civil/administrative subdivision of a county, used for governance and land survey

Townships are pervasive in records from the U.S. Midwest and Northeast (Public Land Survey System states), making this a valuable addition to the standard vocabulary.

## Changes
- Added `township` place type to `specification/5-standard-vocabularies/place-types.glx`
- Category: `administrative` (consistent with county, state, etc.)
