### PR TITLE
fix: append residence on PLAC-without-DATE instead of overwriting

### DIFF
--- a/go-glx/gedcom_import_test.go
+++ b/go-glx/gedcom_import_test.go
@@ -487,6 +487,34 @@ func TestConvertResidence_PlaceWithoutDateAppendsToExisting(t *testing.T) {
 	}
 }
 
+// TestConvertResidence_TwoUndatedAppendsToList tests that two consecutive RESI with PLAC
+// but no DATE both get preserved (covers the non-list append branch).
+func TestConvertResidence_TwoUndatedAppendsToList(t *testing.T) {
+	gedcom := `0 HEAD
+1 GEDC
+2 VERS 5.5.1
+0 @I1@ INDI
+1 NAME Carol /Test/
+1 RESI
+2 PLAC London, England
+1 RESI
+2 PLAC Paris, France
+0 TRLR`
+
+	reader := strings.NewReader(gedcom)
+	glx, _, err := ImportGEDCOM(reader, nil)
+	require.NoError(t, err)
+
+	for _, p := range glx.Persons {
+		res, hasResidence := p.Properties[PersonPropertyResidence]
+		require.True(t, hasResidence, "Person should have residence property")
+
+		resList, ok := res.([]any)
+		require.True(t, ok, "Residence should be a list when multiple undated entries exist, got %T", res)
+		assert.Len(t, resList, 2, "Both undated residence entries should be preserved")
+	}
+}
+
 // TestConvertCensus_PlaceWithoutDateAppendsToExisting tests that CENS with PLAC but no DATE
 // appends to existing residence list instead of overwriting it (issue #14).
 func TestConvertCensus_PlaceWithoutDateAppendsToExisting(t *testing.T) {

--- a/go-glx/gedcom_individual.go
+++ b/go-glx/gedcom_individual.go
@@ -408,6 +408,29 @@ func buildPlaceHierarchyFromAddress(addrRecord *GEDCOMRecord) *PlaceHierarchy {
 	}
 }
 
+// appendResidence appends a residence value to a person's residence property.
+// The value may be a temporal map (with date) or a bare place ID string.
+// If the property already exists, it is converted to/appended to a list.
+// If the property does not exist, a bare value is stored directly (scalar for
+// a single undated entry, single-element list for a dated entry).
+func appendResidence(person *Person, value any) {
+	existing, exists := person.Properties[PersonPropertyResidence]
+	if !exists {
+		// Temporal entries (maps with date) always start as a list
+		if _, isMap := value.(map[string]any); isMap {
+			person.Properties[PersonPropertyResidence] = []any{value}
+		} else {
+			person.Properties[PersonPropertyResidence] = value
+		}
+		return
+	}
+	if existingList, ok := existing.([]any); ok {
+		person.Properties[PersonPropertyResidence] = append(existingList, value)
+	} else {
+		person.Properties[PersonPropertyResidence] = []any{existing, value}
+	}
+}
+
 // convertResidence converts RESI to residence temporal property on person
 func convertResidence(personID string, person *Person, resiRecord *GEDCOMRecord, conv *ConversionContext) {
 	// Extract place and date from RESI record
@@ -428,35 +451,13 @@ func convertResidence(personID string, person *Person, resiRecord *GEDCOMRecord,
 
 	// If we have a place, create temporal property
 	if placeID != "" {
-		// Build temporal value with date if present
 		if dateStr != "" {
-			// Add as temporal property with date
-			temporalValue := map[string]any{
+			appendResidence(person, map[string]any{
 				"value": placeID,
 				"date":  dateStr,
-			}
-			// Append to existing residence history or create new
-			if existing, ok := person.Properties[PersonPropertyResidence]; ok {
-				if existingList, ok := existing.([]any); ok {
-					person.Properties[PersonPropertyResidence] = append(existingList, temporalValue)
-				} else {
-					// Convert single value to list
-					person.Properties[PersonPropertyResidence] = []any{existing, temporalValue}
-				}
-			} else {
-				person.Properties[PersonPropertyResidence] = []any{temporalValue}
-			}
+			})
 		} else {
-			// No date - append place to existing residence list
-			if existing, ok := person.Properties[PersonPropertyResidence]; ok {
-				if existingList, ok := existing.([]any); ok {
-					person.Properties[PersonPropertyResidence] = append(existingList, placeID)
-				} else {
-					person.Properties[PersonPropertyResidence] = []any{existing, placeID}
-				}
-			} else {
-				person.Properties[PersonPropertyResidence] = placeID
-			}
+			appendResidence(person, placeID)
 		}
 
 		// Create assertion for the residence
@@ -612,30 +613,12 @@ func applyCensusData(personID string, person *Person, data censusData, conv *Con
 	}
 
 	if data.dateStr != "" {
-		temporalValue := map[string]any{
+		appendResidence(person, map[string]any{
 			"value": data.placeID,
 			"date":  data.dateStr,
-		}
-		if existing, ok := person.Properties[PersonPropertyResidence]; ok {
-			if existingList, ok := existing.([]any); ok {
-				person.Properties[PersonPropertyResidence] = append(existingList, temporalValue)
-			} else {
-				person.Properties[PersonPropertyResidence] = []any{existing, temporalValue}
-			}
-		} else {
-			person.Properties[PersonPropertyResidence] = []any{temporalValue}
-		}
+		})
 	} else {
-		// No date - append place to existing residence list
-		if existing, ok := person.Properties[PersonPropertyResidence]; ok {
-			if existingList, ok := existing.([]any); ok {
-				person.Properties[PersonPropertyResidence] = append(existingList, data.placeID)
-			} else {
-				person.Properties[PersonPropertyResidence] = []any{existing, data.placeID}
-			}
-		} else {
-			person.Properties[PersonPropertyResidence] = data.placeID
-		}
+		appendResidence(person, data.placeID)
 	}
 
 	// Create assertion for residence backed by citations


### PR DESCRIPTION
## Summary

- Fixes `convertResidence` and `applyCensusData` to append PLAC-without-DATE entries to the existing residence list instead of overwriting it
- Adds two regression tests reproducing the silent data loss

Closes #14

## Example

Given this GEDCOM input:

```gedcom
0 @I1@ INDI
1 NAME Alice /Test/
1 RESI
2 DATE 1900
2 PLAC London, England
1 RESI
2 PLAC Paris, France
```

**Before (bug)** — second RESI silently overwrites the first:

```yaml
residence: place-a1b2c3d4  # Paris only; London entry lost
```

**After (fix)** — both entries preserved:

```yaml
residence:
  - value: place-e5f6a7b8
    date: "1900"            # London, 1900
  - place-a1b2c3d4          # Paris, undated
```

## Test plan

- [x] `TestConvertResidence_PlaceWithoutDateAppendsToExisting` — RESI with DATE+PLAC followed by RESI with only PLAC preserves both entries
- [x] `TestConvertCensus_PlaceWithoutDateAppendsToExisting` — RESI with DATE+PLAC followed by CENS with only PLAC preserves both entries
- [x] All existing tests pass (`make test`)