### PR TITLE
feat: auto-resolve Copilot review suggestions with Claude Code

### DIFF
--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -6,10 +6,11 @@ on:
 
 jobs:
   auto-fix:
-    # Only trigger on Copilot reviews with comments (not approvals/request-changes with no suggestions)
+    # Only trigger on Copilot reviews with comments, and only for same-repo PRs (not forks)
     if: |
       github.event.review.user.login == 'copilot-pull-request-reviewer[bot]' &&
-      github.event.review.state == 'commented'
+      github.event.review.state == 'commented' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     # Prevent loops: only one run per PR at a time, cancel in-progress if re-triggered
     concurrency:
@@ -24,6 +25,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 
@@ -45,8 +47,9 @@ jobs:
                a. Read and understand the suggestion
                b. If it's a valid code improvement, make the fix in the codebase
                c. If it's not actionable (e.g. asking for tests that already exist, or suggesting changes that would break things), skip it but still reply explaining why
-            3. After making all code fixes, commit and push them in a single commit with message "fix: address Copilot review suggestions"
-            4. Reply to each Copilot comment explaining what was done
+            3. Only if there are actual file changes: commit and push in a single commit with message "fix: address Copilot review suggestions"
+               If no files were changed, skip the commit/push step entirely.
+            4. Reply to each Copilot comment explaining what was done (or why it was skipped)
             5. Resolve each thread using the GraphQL resolveReviewThread mutation
 
             Important rules:
@@ -55,3 +58,4 @@ jobs:
             - Do NOT modify files unrelated to the suggestions
             - If a suggestion seems wrong or would break something, reply explaining why and resolve the thread anyway
             - Keep changes minimal and focused
+            - Do NOT commit if there are no file changes — just reply and resolve


### PR DESCRIPTION
## Summary

- Adds a new GitHub Actions workflow that automatically resolves Copilot review suggestions using Claude Code
- When Copilot posts a review on any PR, Claude reads the unresolved threads, makes code fixes, pushes a commit, replies to each comment, and resolves the threads
- Eliminates the manual cycle of checking for Copilot comments, fixing code, replying, and resolving

## How it works

1. **Trigger**: `pull_request_review` event from `copilot-pull-request-reviewer[bot]`
2. **Claude Code Action** runs with write permissions on the PR branch
3. Claude reads unresolved threads via GraphQL, makes fixes, commits, replies, and resolves
4. **Concurrency guard**: one run per PR at a time with `cancel-in-progress: true` to prevent loops

## Safety

- Only triggers on Copilot bot reviews (not human reviews)
- Concurrency group per PR prevents infinite loops (if Claude's push triggers a new Copilot review, the in-progress run is cancelled)
- Cannot push to main (only PR branches)
- Follows CLAUDE.md conventions

## Test plan

- [ ] Merge this PR, then push a change to any open PR
- [ ] Verify the workflow triggers when Copilot posts its review
- [ ] Verify Claude makes appropriate fixes and resolves threads
- [ ] Verify no infinite loop occurs (concurrency cancellation works)