### PR TITLE
fix: switch copilot-auto-fix to schedule + GitHub App token

### DIFF
--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           # Get all open same-repo PRs (exclude forks)
           PRS=$(gh pr list --repo "${{ github.repository }}" \
-            --state open --json number,headRefName,isCrossRepository \
+            --state open --limit 999 --json number,headRefName,isCrossRepository \
             --jq '.[] | select(.isCrossRepository == false) | .number')
 
           for PR_NUMBER in $PRS; do
@@ -38,7 +38,7 @@ jobs:
               query($owner: String!, $name: String!, $pr: Int!) {
                 repository(owner: $owner, name: $name) {
                   pullRequest(number: $pr) {
-                    reviewThreads(first: 50) {
+                    reviewThreads(first: 100) {
                       nodes {
                         isResolved
                         comments(first: 1) {


### PR DESCRIPTION
## Summary
- Switch from `workflow_run` trigger (which always requires manual approval for bot-triggered events) to `schedule` trigger (every 15 min)
- Use GitHub App token via `actions/create-github-app-token@v1` so pushes trigger subsequent workflows (e.g., Copilot re-review)
- Scans all open PRs for unresolved Copilot threads, processes the first one found per run

## Setup required
1. Create a GitHub App with `contents:write`, `pull-requests:write`, `issues:write` permissions
2. Install it on the `genealogix/glx` repo
3. Add repo secrets:
   - `GH_APP_ID` — the App ID
   - `GH_APP_PRIVATE_KEY` — the App's private key (PEM format)

## Test plan
- [ ] Create GitHub App and configure secrets
- [ ] Verify scheduled runs appear in Actions tab without `action_required`
- [ ] Verify unresolved Copilot threads are detected and processed
- [ ] Verify pushes from the workflow trigger Copilot re-review