### PR TITLE
feat: add missing event and relationship types to vocabularies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 #### Standard Vocabularies
 - **Added `original_place_name` citation property** - Records the verbatim place name from a source before normalization to a place entity (e.g., "The Town Of Marston" vs the normalized place reference)
 - **Added relationship types `neighbor`, `coworker`, `housemate`** - Non-familial relationships commonly found in census, tax, and social records
+- **Added relationship types `apprenticeship`, `employment`, `enslavement`, `relative`** - Master-apprentice, employer-employee, enslaver-enslaved, and generic kinship relationships
 - **Added event types `legal_separation`, `taxation`, `voter_registration`** - Legal/administrative events for separations, tax rolls, and voter rolls
+- **Added event types `military_service`, `stillborn`, `affiliation`** - Military service periods, stillbirths, and organizational memberships
 - **Added source types `population_register`, `tax_record`, `notarial_record`** - Common European and colonial record types
 - **Expanded `military` source type description** - Now includes draft registrations and muster rolls
 

--- a/specification/5-standard-vocabularies/event-types.glx
+++ b/specification/5-standard-vocabularies/event-types.glx
@@ -205,6 +205,23 @@ event_types:
     description: "Registration to vote or appearance on a voter roll"
     category: "legal"
 
+  # Military and Service Events
+  military_service:
+    label: "Military Service"
+    description: "Period of military service, enlistment, or conscription"
+    category: "lifecycle"
+
+  # Other Lifecycle Events
+  stillborn:
+    label: "Stillborn"
+    description: "Stillbirth"
+    category: "lifecycle"
+
+  affiliation:
+    label: "Affiliation"
+    description: "Membership or association with an organization, society, or group"
+    category: "other"
+
   # Census Events
   census:
     label: "Census"

--- a/specification/5-standard-vocabularies/relationship-types.glx
+++ b/specification/5-standard-vocabularies/relationship-types.glx
@@ -61,3 +61,19 @@ relationship_types:
     label: "Housemate"
     description: "People who shared a household without a family relationship"
 
+  apprenticeship:
+    label: "Apprenticeship"
+    description: "Master-apprentice relationship for learning a trade or skill"
+
+  employment:
+    label: "Employment"
+    description: "Employer-employee relationship"
+
+  enslavement:
+    label: "Enslavement"
+    description: "Enslaver-enslaved relationship"
+
+  relative:
+    label: "Relative"
+    description: "Generic kinship relationship when the specific type is unknown or not applicable"
+


### PR DESCRIPTION
## Summary
- Adds 3 new event types: `military_service`, `stillborn`, `affiliation`
- Adds 4 new relationship types: `apprenticeship`, `employment`, `enslavement`, `relative`

These are standard genealogical concepts needed by the `glx summary` command (PR #77) and commonly encountered in historical records.

### New Event Types
| Type | Category | Description |
|------|----------|-------------|
| `military_service` | lifecycle | Period of military service, enlistment, or conscription |
| `stillborn` | lifecycle | Stillbirth |
| `affiliation` | other | Membership or association with an organization, society, or group |

### New Relationship Types
| Type | Description |
|------|-------------|
| `apprenticeship` | Master-apprentice relationship for learning a trade or skill |
| `employment` | Employer-employee relationship |
| `enslavement` | Enslaver-enslaved relationship |
| `relative` | Generic kinship when specific type is unknown |

## Test plan
- [ ] validate-schemas passes (vocabulary files are valid YAML)
- [ ] validate-examples passes (example archives reference vocabularies via symlinks)
- [ ] No breaking changes to existing vocabulary entries