### PR TITLE
fix: redesign copilot-auto-fix from schedule to event-driven

### DIFF
--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -14,8 +14,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      issues: write
-      id-token: write
     concurrency:
       group: copilot-auto-fix-${{ github.event.pull_request.number }}
       cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Replaces the 15-minute schedule polling with a `pull_request_review` event trigger that fires immediately when Copilot submits a review
- Fixes the persistent "Bad credentials" error caused by OIDC `additional_permissions` token exchange failing in schedule context
- Passes the GitHub App token directly as `github_token` instead of relying on `additional_permissions`
- Adds per-PR concurrency groups and fork-PR safety check

### Root cause
The old workflow used `schedule` trigger + `additional_permissions` in `claude-code-action`. The `additional_permissions` feature uses OIDC to request an installation token, but this exchange fails in schedule context with no PR event — every run for the past weeks has failed with `"Bad credentials"`.

### New design
Event-driven: the workflow triggers on `pull_request_review` events and filters for `copilot-pull-request-reviewer` as the author. This gives proper PR context, eliminates the PR-finding shell script, and responds to Copilot reviews immediately instead of polling.

## Test plan
- [x] Verified old workflow logs show consistent "Bad credentials" failures
- [ ] After merge, next Copilot review on any PR should trigger the workflow successfully