### PR TITLE
feat: auto-resolve CHANGELOG conflicts in PRs

### DIFF
--- a/.github/workflows/auto-resolve-conflicts.yml
+++ b/.github/workflows/auto-resolve-conflicts.yml
@@ -48,7 +48,7 @@ jobs:
             exit 0
           fi
 
-          echo "$CONFLICTING_PRS" | while read -r PR_NUMBER BRANCH; do
+          while read -r PR_NUMBER BRANCH; do
             echo "=== PR #$PR_NUMBER ($BRANCH) ==="
 
             # Clean state for each PR
@@ -65,7 +65,7 @@ jobs:
             fi
 
             # Attempt merge
-            MERGE_OUTPUT=$(git merge origin/main --no-edit 2>&1) || true
+            git merge origin/main --no-edit 2>&1 || true
 
             # Get list of conflicted files
             CONFLICTED_FILES=$(git diff --name-only --diff-filter=U 2>/dev/null)
@@ -99,7 +99,10 @@ jobs:
 
             # Stage and commit
             git add CHANGELOG.md
-            git commit --no-edit 2>/dev/null
+            if ! git commit --no-edit; then
+              echo "  Commit failed — skipping"
+              continue
+            fi
 
             # Push to the PR branch
             if git push origin "HEAD:$BRANCH" 2>/dev/null; then
@@ -107,4 +110,4 @@ jobs:
             else
               echo "  Failed to push — skipping"
             fi
-          done
+          done < <(echo "$CONFLICTING_PRS")


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically resolves CHANGELOG.md merge conflicts in open PRs
- Triggers on push to main (when conflicts appear) and hourly as a fallback
- Only resolves conflicts when CHANGELOG.md is the **only** conflicted file — skips PRs with other file conflicts for manual resolution
- Uses a "keep both sides" strategy (removes conflict markers, preserves all entries)

## How it works
1. Lists all open PRs with `CONFLICTING` mergeable status
2. For each, attempts `git merge origin/main`
3. If only CHANGELOG.md is conflicted, removes conflict markers and commits
4. If other files are conflicted, aborts and skips

## Test plan
- [ ] Verify workflow runs on push to main
- [ ] Create a PR with only a CHANGELOG conflict and confirm auto-resolution
- [ ] Create a PR with CHANGELOG + another file conflict and confirm it's skipped
- [ ] Verify no conflict markers remain after resolution