### PR TITLE
feat: convert non-UTF-8 GEDCOM encodings to UTF-8 on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - **Added `blob_size` media property** - Size in bytes of inline binary data from GEDCOM 5.5.1 BLOB records. Was used in GEDCOM media import but missing from standard vocabulary
 
 ### Fixed
+- **GEDCOM import now converts non-UTF-8 encodings** - Files with `CHAR ANSI` (Windows-1252), `CHAR cp1252`, `CHAR ANSEL`, or `CHAR ISO-8859-1` are now automatically converted to UTF-8 during import. Previously, non-ASCII characters (German umlauts, accented letters, copyright symbols) were stored as raw bytes, producing `!!binary` YAML tags, garbled event titles, and `{"type":"Buffer"}` place names in the web UI
 - **GEDCOM date import mangled when day-of-month matches level number** - Dates like `2 AUG 1944` (day 2) were imported as `2 DATE 2 AUG 1944` because the parser's value extraction matched the level number instead of the actual value. Fixed by walking past tokens positionally instead of using string search
 - **Date year extraction now handles 1–3 digit years** - Year extraction previously hardcoded a 4-digit assumption (`\d{4}`), silently ignoring dates like `800`, `476`, or `ABT 476`. All four extraction sites (query filtering, timeline sorting, temporal validation, event titles) now support 1–4 digit years. Day-of-month values (e.g., `15` in `15 MAR 1850`) are correctly disambiguated. Timeline sort keys are zero-padded to 4 digits for proper chronological ordering. Fixes #108
 

--- a/go-glx/gedcom_encoding.go
+++ b/go-glx/gedcom_encoding.go
@@ -1,0 +1,208 @@
+// Copyright 2025 Oracynth, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package glx
+
+import (
+	"bytes"
+	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/charmap"
+	"golang.org/x/text/transform"
+)
+
+// convertToUTF8 detects the GEDCOM CHAR encoding from the header and converts
+// the raw bytes to UTF-8 if needed. UTF-8, ASCII, and unknown encodings pass
+// through unchanged.
+func convertToUTF8(data []byte) []byte {
+	charset := detectGEDCOMCharset(data)
+
+	var enc encoding.Encoding
+
+	switch strings.ToUpper(charset) {
+	case "ANSI", "CP1252", "WINDOWS-1252":
+		enc = charmap.Windows1252
+	case "ANSEL":
+		return convertANSELToUTF8(data)
+	case "ISO-8859-1", "ISO8859-1", "LATIN1":
+		enc = charmap.ISO8859_1
+	default:
+		// UTF-8, ASCII, empty, or unknown — pass through
+		return data
+	}
+
+	result, _, err := transform.Bytes(enc.NewDecoder(), data)
+	if err != nil {
+		return data // fall back to raw bytes on error
+	}
+
+	return result
+}
+
+// detectGEDCOMCharset scans the first ~20 lines for "1 CHAR <value>" and
+// returns the charset string. The CHAR line is always in the HEAD record near
+// the top of the file, so a limited scan is sufficient.
+func detectGEDCOMCharset(data []byte) string {
+	// Scan up to 2KB or end of data for the CHAR line
+	limit := 2048
+	if len(data) < limit {
+		limit = len(data)
+	}
+
+	chunk := string(data[:limit])
+
+	for _, line := range strings.Split(chunk, "\n") {
+		line = strings.TrimRight(line, "\r")
+		fields := strings.Fields(line)
+		if len(fields) >= 3 && fields[0] == "1" && strings.ToUpper(fields[1]) == "CHAR" {
+			return fields[2]
+		}
+	}
+
+	return ""
+}
+
+// anselToUTF8 maps ANSEL non-combining characters (0x80–0xBF range and select
+// others) to their Unicode equivalents. Only the most common characters used
+// in genealogical data are included.
+var anselToUTF8 = map[byte]rune{
+	0xA1: 0x0141, // Ł (L with stroke)
+	0xA2: 0x00D8, // Ø (O with stroke)
+	0xA3: 0x0110, // Đ (D with stroke)
+	0xA4: 0x00DE, // Þ (Thorn)
+	0xA5: 0x00C6, // Æ
+	0xA6: 0x0152, // Œ
+	0xA7: 0x02B9, // ʹ (soft sign)
+	0xA8: 0x00B7, // · (middle dot)
+	0xA9: 0x266D, // ♭ (flat)
+	0xAA: 0x00AE, // ® (registered)
+	0xAB: 0x00B1, // ± (plus-minus)
+	0xAC: 0x01A0, // Ơ (O with horn)
+	0xAD: 0x01AF, // Ư (U with horn)
+	0xAE: 0x02BC, // ʼ (alif)
+	0xB0: 0x02BB, // ʻ (ayn)
+	0xB1: 0x0142, // ł (l with stroke)
+	0xB2: 0x00F8, // ø (o with stroke)
+	0xB3: 0x0111, // đ (d with stroke)
+	0xB4: 0x00FE, // þ (thorn)
+	0xB5: 0x00E6, // æ
+	0xB6: 0x0153, // œ
+	0xB7: 0x02BA, // ʺ (hard sign)
+	0xB8: 0x0131, // ı (dotless i)
+	0xB9: 0x00A3, // £ (pound)
+	0xBA: 0x00F0, // ð (eth)
+	0xBC: 0x01A1, // ơ (o with horn)
+	0xBD: 0x01B0, // ư (u with horn)
+	0xC0: 0x00B0, // ° (degree)
+	0xC1: 0x2113, // ℓ (script l)
+	0xC2: 0x00A9, // © (copyright)
+	0xC3: 0x00A9, // © (copyright — ANSEL standard)
+	0xC4: 0x266F, // ♯ (sharp)
+	0xC5: 0x00BF, // ¿ (inverted question)
+	0xC6: 0x00A1, // ¡ (inverted exclamation)
+	0xCF: 0x00DF, // ß (eszett)
+}
+
+// anselCombining maps ANSEL combining diacritical marks (0xE0–0xFE) to Unicode
+// combining characters. In ANSEL, the diacritical precedes the base letter;
+// in Unicode, combining characters follow the base letter.
+var anselCombining = map[byte]rune{
+	0xE0: 0x0309, // combining hook above
+	0xE1: 0x0300, // combining grave accent
+	0xE2: 0x0301, // combining acute accent
+	0xE3: 0x0302, // combining circumflex
+	0xE4: 0x0303, // combining tilde
+	0xE5: 0x0304, // combining macron
+	0xE6: 0x0306, // combining breve
+	0xE7: 0x0307, // combining dot above
+	0xE8: 0x0308, // combining diaeresis (umlaut)
+	0xE9: 0x030C, // combining caron (hacek)
+	0xEA: 0x030A, // combining ring above
+	0xEB: 0x0FE0, // combining ligature left half (approx)
+	0xEC: 0x0FE1, // combining ligature right half (approx)
+	0xED: 0x0315, // combining comma above right
+	0xEE: 0x030B, // combining double acute
+	0xEF: 0x0310, // combining candrabindu
+	0xF0: 0x0327, // combining cedilla
+	0xF1: 0x0328, // combining ogonek
+	0xF2: 0x0323, // combining dot below
+	0xF3: 0x0324, // combining diaeresis below
+	0xF4: 0x0325, // combining ring below
+	0xF5: 0x0333, // combining double low line
+	0xF6: 0x0332, // combining low line
+	0xF7: 0x0326, // combining comma below
+	0xF8: 0x031C, // combining left half ring below
+	0xF9: 0x032E, // combining breve below
+	0xFE: 0x0313, // combining comma above
+}
+
+// convertANSELToUTF8 converts ANSEL-encoded bytes to UTF-8. ANSEL uses
+// combining diacriticals (0xE0–0xFE) that precede the base letter, so the
+// converter reorders them to follow the base letter (Unicode order).
+func convertANSELToUTF8(data []byte) []byte {
+	var buf bytes.Buffer
+	buf.Grow(len(data))
+
+	i := 0
+	for i < len(data) {
+		b := data[i]
+
+		// ASCII passthrough
+		if b < 0x80 {
+			buf.WriteByte(b)
+			i++
+			continue
+		}
+
+		// Combining diacritical (precedes base letter in ANSEL)
+		if combiningRune, ok := anselCombining[b]; ok {
+			// Next byte should be the base letter
+			if i+1 < len(data) {
+				base := data[i+1]
+				if base < 0x80 {
+					// Write base letter first, then combining mark (Unicode order)
+					buf.WriteByte(base)
+					var runeBytes [4]byte
+					n := utf8.EncodeRune(runeBytes[:], combiningRune)
+					buf.Write(runeBytes[:n])
+					i += 2
+					continue
+				}
+			}
+			// No valid base letter follows — write the combining mark alone
+			var runeBytes [4]byte
+			n := utf8.EncodeRune(runeBytes[:], combiningRune)
+			buf.Write(runeBytes[:n])
+			i++
+			continue
+		}
+
+		// Non-combining ANSEL character
+		if r, ok := anselToUTF8[b]; ok {
+			var runeBytes [4]byte
+			n := utf8.EncodeRune(runeBytes[:], r)
+			buf.Write(runeBytes[:n])
+			i++
+			continue
+		}
+
+		// Unknown high byte — replace with Unicode replacement character
+		buf.WriteRune(utf8.RuneError)
+		i++
+	}
+
+	return buf.Bytes()
+}

--- a/go-glx/gedcom_encoding_test.go
+++ b/go-glx/gedcom_encoding_test.go
@@ -1,0 +1,185 @@
+// Copyright 2025 Oracynth, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package glx
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertToUTF8_CP1252(t *testing.T) {
+	// "1 TITL König" in CP1252: ö = 0xF6
+	input := []byte("0 HEAD\r\n1 CHAR ANSI\r\n0 @I1@ INDI\r\n1 TITL K\xf6nig\r\n")
+
+	got := convertToUTF8(input)
+
+	assert.Contains(t, string(got), "König")
+	assert.NotContains(t, string(got), "\xf6")
+}
+
+func TestConvertToUTF8_CP1252Explicit(t *testing.T) {
+	// CHAR cp1252 (as used by Gramps exports)
+	input := []byte("0 HEAD\n1 CHAR cp1252\n0 @I1@ INDI\n1 TITL Z\xfcrich\n")
+
+	got := convertToUTF8(input)
+
+	assert.Contains(t, string(got), "Zürich")
+}
+
+func TestConvertToUTF8_ANSEL(t *testing.T) {
+	// ANSEL copyright symbol: 0xC3 = ©
+	input := []byte("0 HEAD\n1 CHAR ANSEL\n0 @N1@ NOTE \xc3 2024 by Author\n")
+
+	got := convertToUTF8(input)
+
+	assert.Contains(t, string(got), "© 2024 by Author")
+}
+
+func TestConvertToUTF8_ANSELCombiningDiacritics(t *testing.T) {
+	// ANSEL combining hook above (0xE0) precedes base letter
+	// 0xE0 + 'A' = À (A with hook above / grave accent)
+	input := []byte("0 HEAD\n1 CHAR ANSEL\n0 @I1@ INDI\n1 NAME \xe0A\n")
+
+	got := convertToUTF8(input)
+
+	// The combining diacritical should produce a valid UTF-8 character
+	assert.True(t, isValidUTF8(got), "output should be valid UTF-8")
+}
+
+func TestConvertToUTF8_UTF8Passthrough(t *testing.T) {
+	// UTF-8 input should pass through unchanged
+	input := []byte("0 HEAD\n1 CHAR UTF-8\n0 @I1@ INDI\n1 TITL König\n")
+
+	got := convertToUTF8(input)
+
+	assert.Equal(t, input, got)
+}
+
+func TestConvertToUTF8_ASCIIPassthrough(t *testing.T) {
+	input := []byte("0 HEAD\n1 CHAR ASCII\n0 @I1@ INDI\n1 NAME John /Smith/\n")
+
+	got := convertToUTF8(input)
+
+	assert.Equal(t, input, got)
+}
+
+func TestConvertToUTF8_NoCHARDefaultsToPassthrough(t *testing.T) {
+	// No CHAR header — assume UTF-8
+	input := []byte("0 HEAD\n1 GEDC\n2 VERS 5.5.1\n0 @I1@ INDI\n")
+
+	got := convertToUTF8(input)
+
+	assert.Equal(t, input, got)
+}
+
+func TestImport_CP1252PlaceNames(t *testing.T) {
+	// Full GEDCOM with CP1252-encoded place name containing ß (0xDF)
+	gedcom := "0 HEAD\r\n" +
+		"1 GEDC\r\n" +
+		"2 VERS 5.5\r\n" +
+		"1 CHAR ANSI\r\n" +
+		"0 @I1@ INDI\r\n" +
+		"1 NAME Johann /Habsburg/\r\n" +
+		"1 BIRT\r\n" +
+		"2 DATE 15 MAR 1500\r\n" +
+		"2 PLAC Stra\xdfburg\r\n" +
+		"0 TRLR\r\n"
+
+	glxFile, _, err := ImportGEDCOM(bytes.NewReader([]byte(gedcom)), io.Discard)
+	require.NoError(t, err)
+
+	// The place name should be valid UTF-8 "Straßburg"
+	foundPlace := false
+	for _, place := range glxFile.Places {
+		if place.Name == "Straßburg" {
+			foundPlace = true
+			break
+		}
+	}
+	assert.True(t, foundPlace, "should find place with properly decoded name 'Straßburg'")
+}
+
+func TestImport_CP1252PersonTitle(t *testing.T) {
+	// CP1252 title with ö (0xF6)
+	gedcom := "0 HEAD\r\n" +
+		"1 GEDC\r\n" +
+		"2 VERS 5.5\r\n" +
+		"1 CHAR ANSI\r\n" +
+		"0 @I1@ INDI\r\n" +
+		"1 NAME Franz /Habsburg/\r\n" +
+		"1 TITL K\xf6nig\r\n" +
+		"0 TRLR\r\n"
+
+	glxFile, _, err := ImportGEDCOM(bytes.NewReader([]byte(gedcom)), io.Discard)
+	require.NoError(t, err)
+
+	// Find person and check title property contains decoded UTF-8
+	for _, person := range glxFile.Persons {
+		if title, ok := person.Properties["title"]; ok {
+			// Title may be stored as a string or temporal list with "value" key
+			switch v := title.(type) {
+			case string:
+				assert.Equal(t, "König", v, "title should be decoded from CP1252 to UTF-8")
+			case map[string]any:
+				assert.Equal(t, "König", v["value"], "title value should be decoded from CP1252 to UTF-8")
+			case []any:
+				require.NotEmpty(t, v)
+				m, ok := v[0].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "König", m["value"], "title value should be decoded from CP1252 to UTF-8")
+			default:
+				t.Fatalf("unexpected title type: %T", title)
+			}
+			return
+		}
+	}
+	t.Fatal("expected person with title property")
+}
+
+func TestImport_CP1252EventTitle(t *testing.T) {
+	// Event title generated from CP1252-encoded name with ü (0xFC)
+	gedcom := "0 HEAD\r\n" +
+		"1 GEDC\r\n" +
+		"2 VERS 5.5\r\n" +
+		"1 CHAR ANSI\r\n" +
+		"0 @I1@ INDI\r\n" +
+		"1 NAME G\xfcnter /M\xfcller/\r\n" +
+		"1 BIRT\r\n" +
+		"2 DATE 1 JAN 1900\r\n" +
+		"0 TRLR\r\n"
+
+	glxFile, _, err := ImportGEDCOM(bytes.NewReader([]byte(gedcom)), io.Discard)
+	require.NoError(t, err)
+
+	// Event title should contain properly decoded name
+	for _, event := range glxFile.Events {
+		if event.Type == EventTypeBirth {
+			assert.Contains(t, string(event.Title), "Günter", "event title should contain decoded name")
+			assert.Contains(t, string(event.Title), "Müller", "event title should contain decoded surname")
+			return
+		}
+	}
+	t.Fatal("expected birth event")
+}
+
+// isValidUTF8 checks if all bytes form valid UTF-8.
+func isValidUTF8(b []byte) bool {
+	return utf8.Valid(b)
+}

--- a/go-glx/gedcom_import.go
+++ b/go-glx/gedcom_import.go
@@ -16,6 +16,7 @@ package glx
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"strconv"
@@ -428,9 +429,18 @@ func parseGEDCOM(reader io.Reader, logger *ImportLogger) ([]*GEDCOMRecord, GEDCO
 
 // parseGEDCOMLines parses GEDCOM file line by line
 func parseGEDCOMLines(reader io.Reader) ([]*GEDCOMLine, error) {
+	// Read all bytes so we can detect the CHAR encoding header and convert
+	// non-UTF-8 encodings (ANSI/CP1252, ANSEL, ISO-8859-1) before parsing.
+	rawBytes, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("reading input: %w", err)
+	}
+
+	rawBytes = convertToUTF8(rawBytes)
+
 	var lines []*GEDCOMLine
 
-	scanner := bufio.NewScanner(reader)
+	scanner := bufio.NewScanner(bytes.NewReader(rawBytes))
 	// Handle all line ending formats: LF, CRLF, and CR (old Mac Classic)
 	scanner.Split(scanLinesAllEndings)
 

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/text v0.34.0 // indirect
 )
 
 // CLI tool for GENEALOGIX archives

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=
+golang.org/x/text v0.34.0/go.mod h1:homfLqTYRFyVYemLBFl5GgL/DWEiH5wcsQ5gSh1yziA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Summary
- **Auto-detect and convert GEDCOM character encodings** — Files with `CHAR ANSI` (Windows-1252), `CHAR cp1252`, `CHAR ANSEL`, or `CHAR ISO-8859-1` headers are now converted to UTF-8 before parsing
- **Fixes garbled habsburg import** — German umlauts (ö, ü, ß), accented letters, and copyright symbols were stored as raw bytes, producing `!!binary` YAML tags, numeric event titles, and `{"type":"Buffer"}` place names in the web UI
- **ANSEL support** — Handles both non-combining characters (©, Æ, ß, etc.) and combining diacriticals with proper Unicode reordering (ANSEL puts diacriticals before base letters; Unicode puts them after)

## Test plan
- [x] 7 unit tests for `convertToUTF8`: CP1252, ANSEL, ANSEL combining, UTF-8 passthrough, ASCII passthrough, no-CHAR default, explicit cp1252
- [x] 3 integration tests: CP1252 place names (Straßburg), CP1252 person titles (König), CP1252 event titles (Günter Müller)
- [x] Habsburg GEDCOM: zero `!!binary` tags, proper UTF-8 place names (was showing Buffer objects)
- [x] All existing tests pass (Kennedy, Shakespeare, torture tests, etc.)