### PR TITLE
fix: Add go-glx/ package to CI test suite

### DIFF
--- a/.github/workflows/validate-spec.yml
+++ b/.github/workflows/validate-spec.yml
@@ -70,5 +70,7 @@ jobs:
           go test ./glx/... ./go-glx/... -v -timeout 15m
       
       - name: Build glx CLI
-        run: go build -o bin/glx ./glx
+        run: |
+          mkdir -p bin
+          go build -o bin/glx ./glx
 


### PR DESCRIPTION
## Summary

- Add `./go-glx/...` to the CI test command alongside `./glx/...`
- Remove dead "Run Conformance Tests" step that only echoed a message

## Why

The `test-conformance` job only tested the CLI package (`./glx/...`). The core library (`./go-glx/...`) — containing serialization, validation, GEDCOM import/export, entity types, rename, merge, and phonetic search — had zero CI test coverage. Library regressions could be merged undetected.

## Related issues

Fixes #255

## Testing

- Both packages pass locally: `go test ./glx/... ./go-glx/...`
- CI will validate this PR runs both packages

## Breaking changes

None.