### PR TITLE
fix: Remove uppercase requirement from PR title lint

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -30,7 +30,3 @@ jobs:
             perf
             ci
           requireScope: false
-          subjectPattern: ^[A-Z].+$
-          subjectPatternError: |
-            The subject "{subject}" must start with an uppercase letter.
-            Example: "feat: Add person search command"


### PR DESCRIPTION
## Summary

Remove the `subjectPattern: ^[A-Z].+$` rule from the PR title linter. This blocks Renovate/Dependabot PRs which auto-generate lowercase subjects (e.g., `chore(deps): refresh`).

The conventional commits spec doesn't mandate capitalization.

## Related issues

Unblocks #337 (Renovate lockfile refresh)

## Testing

After merge, #337's title lint check should pass on re-run.

## Breaking changes

None — relaxes a restriction.