### PR TITLE
docs: add severity classification and no-bounty statement to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,6 +23,21 @@ If you discover a security vulnerability in GLX, please report it responsibly:
   - High: patch release within 1 week
   - Medium/Low: included in next scheduled release
 
+## Severity Classification
+
+We do not use CVSS scores to classify severity. Like the Go security team and the curl project, we find that CVSS is often a poor fit for the actual risk profile of a given vulnerability. Instead, we assess severity based on:
+
+- **Impact** — What can an attacker do? (data loss, code execution, information disclosure, denial of service)
+- **Exploitability** — How difficult is it to exploit, and what access is required?
+- **Affected surface** — Does it affect all users, or only specific configurations?
+- **Real-world risk** — Given that GLX processes local YAML files with no network-facing surface in normal usage, most vulnerabilities are inherently constrained in scope
+
+Severity levels are assigned at our discretion, with the intent to be transparent and consistent.
+
+## Bug Bounty
+
+This project does not offer a paid bug bounty program. We are an open source project maintained by volunteers. Security researchers are welcome to report vulnerabilities via GitHub Security Advisories — we appreciate responsible disclosure and will credit reporters in release notes where appropriate.
+
 ## Security Measures
 
 - **govulncheck** runs in CI on pushes to main, pull requests, and weekly to detect known vulnerabilities in dependencies


### PR DESCRIPTION
Fixes #482

Two gaps in the current SECURITY.md:

## Changes

### 1. Severity Classification section
The fix timeline table references Critical/High/Medium/Low severity levels but never explains how severity is determined. Added a section that:
- Explicitly rejects CVSS (aligned with the Go security team and curl project)
- Defines the criteria we actually use: impact, exploitability, affected surface, real-world risk
- Notes that GLX's local-only processing model naturally constrains scope

### 2. Bug Bounty section  
Silence on whether a bounty program exists wastes researcher time and creates confusion. Added an explicit statement: no paid program, but responsible disclosure is welcome and credited.

## References
- Go security policy (anti-CVSS): https://go.dev/security/policy
- curl bounty discontinuation: https://raw.githubusercontent.com/curl/curl/master/docs/BUG-BOUNTY.md