### PR TITLE
fix: Enable Go module and npm caching in all CI workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.26'
+          cache: true
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.26'
+          cache: true
 
       - name: Run govulncheck
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
@@ -53,6 +54,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.26'
+          cache: true
 
       - name: Install gosec
         run: go install github.com/securego/gosec/v2/cmd/gosec@v2.22.4
@@ -73,6 +75,8 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: website/package-lock.json
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/validate-spec.yml
+++ b/.github/workflows/validate-spec.yml
@@ -19,11 +19,14 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.26'
+          cache: true
 
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
           node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: specification/package-lock.json
 
       - name: Install schema validation deps
         run: npm ci --prefix specification
@@ -41,7 +44,8 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.26'
-      
+          cache: true
+
       - name: Build glx CLI
         run: |
           # Build Go-based CLI tool
@@ -65,7 +69,8 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.26'
-      
+          cache: true
+
       - name: Run Go Tests
         run: |
           # Run all tests for both CLI and core library packages


### PR DESCRIPTION
## What and why

Every CI run downloads all Go modules and npm packages from scratch. The validate-schemas job showed a cache warning: `Cache Size: ~0 MB (7438 B)` — the Go module cache was effectively empty.

### Changes

Added `cache: true` to all 6 `setup-go` steps and `cache: 'npm'` with `cache-dependency-path` to both `setup-node` steps:

| Workflow | Steps changed |
|---|---|
| validate-spec.yml | 3 Go + 1 Node (specification/package-lock.json) |
| security.yml | 2 Go + 1 Node (website/package-lock.json) |
| release.yml | 1 Go |

The `cache-dependency-path` is critical because the repo has two package-lock.json files (website/ and specification/) — without it, setup-node looks in the repo root and misses every time.

### Expected impact

~100-180 seconds saved per PR run (Go module download + build cache + npm cache).

## Related issues

Fixes #278

## Testing

CI on this PR will be the first run to populate the caches. Subsequent runs should show cache hits.

## Breaking changes

None.