### PR TITLE
fix: Add go mod download to populate Go module cache in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ jobs:
           go-version: '1.26'
           cache: true
 
+      - name: Download Go modules
+        run: go mod download
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,6 +28,9 @@ jobs:
           go-version: '1.26'
           cache: true
 
+      - name: Download Go modules
+        run: go mod download
+
       - name: Run govulncheck
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         with:
@@ -55,6 +58,9 @@ jobs:
         with:
           go-version: '1.26'
           cache: true
+
+      - name: Download Go modules
+        run: go mod download
 
       - name: Install gosec
         run: go install github.com/securego/gosec/v2/cmd/gosec@v2.22.4

--- a/.github/workflows/validate-spec.yml
+++ b/.github/workflows/validate-spec.yml
@@ -15,12 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: '1.26'
-          cache: true
-
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
@@ -46,6 +40,9 @@ jobs:
           go-version: '1.26'
           cache: true
 
+      - name: Download Go modules
+        run: go mod download
+
       - name: Build glx CLI
         run: |
           # Build Go-based CLI tool
@@ -70,6 +67,9 @@ jobs:
         with:
           go-version: '1.26'
           cache: true
+
+      - name: Download Go modules
+        run: go mod download
 
       - name: Run Go Tests
         run: |


### PR DESCRIPTION
## What and why

Follow-up to #583. The `cache: true` flag was saving/restoring an empty Go module cache (7 KiB) because no Go command populated `GOMODCACHE` before the post-job cache save.

### Changes

1. **Added `go mod download` step** after `setup-go` in all 5 Go jobs across 3 workflows. This explicitly populates `~/go/pkg/mod` so the cache save captures the full module set (~43 MiB).

2. **Removed `setup-go` from `validate-schemas` job** — this job only runs `node` (npm/Ajv). Setting up Go was wasting ~10 seconds and creating an empty Go cache entry.

### Expected result

First run: cache miss, `go mod download` downloads modules, post-job saves ~43 MiB cache.
Subsequent runs: cache hit, `go mod download` is a no-op (all modules already present), saves ~10-30 seconds per job.

## Related issues

Fixes #278

## Breaking changes

None.