### PR TITLE
ci: Remove dead "Build glx CLI" step from test-conformance

### DIFF
--- a/.github/workflows/validate-spec.yml
+++ b/.github/workflows/validate-spec.yml
@@ -81,9 +81,4 @@ jobs:
           # Run all tests for both CLI and core library packages
           # Includes slow/large file tests (habsburg.ged with 34,020 persons)
           go test ./glx/... ./go-glx/... -v -timeout 15m
-      
-      - name: Build glx CLI
-        run: |
-          mkdir -p bin
-          go build -o bin/glx ./glx
 


### PR DESCRIPTION
## What and why

The `test-conformance` job had a "Build glx CLI" step at the end that built the binary but never used it — no artifact upload, no downstream job, no subsequent step. `go test` already verifies compilation. The `validate-examples` job correctly builds and uses the binary separately.

Likely copy-pasted from `validate-examples` during initial setup.

## Related issues

Closes #348

## Testing

- The workflow itself is the test — CI will run without the dead step
- No code changes, only workflow YAML

## Breaking changes

None