### PR TITLE
fix: Silently skip identical vocabulary entries during merge

### DIFF
--- a/glx/archive_io_test.go
+++ b/glx/archive_io_test.go
@@ -124,10 +124,10 @@ func TestLoadArchive(t *testing.T) {
 					return &testError{"expected 1 person (after merge), got %d", []any{len(glx.Persons)}}
 				}
 				if len(duplicates) != 1 {
-					return &testError{"expected 1 duplicate, got %d", []any{len(duplicates)}}
+					return &testError{"expected 1 conflict, got %d", []any{len(duplicates)}}
 				}
 				if duplicates[0] != "conflict persons ID: person-1" {
-					return &testError{"expected duplicate to be 'conflict persons ID: person-1', got %s", []any{duplicates[0]}}
+					return &testError{"expected conflict to be 'conflict persons ID: person-1', got %s", []any{duplicates[0]}}
 				}
 
 				return nil

--- a/glx/archive_io_test.go
+++ b/glx/archive_io_test.go
@@ -126,8 +126,8 @@ func TestLoadArchive(t *testing.T) {
 				if len(duplicates) != 1 {
 					return &testError{"expected 1 duplicate, got %d", []any{len(duplicates)}}
 				}
-				if duplicates[0] != "duplicate persons ID: person-1" {
-					return &testError{"expected duplicate to be 'duplicate persons ID: person-1', got %s", []any{duplicates[0]}}
+				if duplicates[0] != "conflict persons ID: person-1" {
+					return &testError{"expected duplicate to be 'conflict persons ID: person-1', got %s", []any{duplicates[0]}}
 				}
 
 				return nil

--- a/glx/merge_runner.go
+++ b/glx/merge_runner.go
@@ -24,7 +24,8 @@ import (
 
 // mergeResult holds statistics from a merge operation.
 type mergeResult struct {
-	Duplicates       []string
+	Conflicts        []string
+	IdenticalSkipped int
 	NewPersons       int
 	NewEvents        int
 	NewRelationships int
@@ -47,13 +48,14 @@ func mergeArchivesInMemory(dest, src *glxlib.GLXFile) *mergeResult {
 	// Snapshot counts before merge
 	before := entityCounts(dest)
 
-	duplicates := dest.Merge(src)
+	conflicts, identicalSkipped := dest.Merge(src)
 
 	// Compute new entities added
 	after := entityCounts(dest)
 
 	return &mergeResult{
-		Duplicates:       duplicates,
+		Conflicts:        conflicts,
+		IdenticalSkipped: identicalSkipped,
 		NewPersons:       after.persons - before.persons,
 		NewEvents:        after.events - before.events,
 		NewRelationships: after.relationships - before.relationships,
@@ -190,11 +192,15 @@ func mergeArchives(srcPath, destPath string, dryRun bool) error {
 		fmt.Println("  No new entities to merge.")
 	}
 
-	if len(result.Duplicates) > 0 {
-		fmt.Printf("\n  Duplicates (%d — skipped, destination kept):\n", len(result.Duplicates))
-		for _, d := range result.Duplicates {
+	if len(result.Conflicts) > 0 {
+		fmt.Printf("\n  Conflicts (%d — skipped, destination kept):\n", len(result.Conflicts))
+		for _, d := range result.Conflicts {
 			fmt.Printf("    %s\n", d)
 		}
+	}
+
+	if result.IdenticalSkipped > 0 {
+		fmt.Printf("\n  %d identical vocabulary/property entries skipped\n", result.IdenticalSkipped)
 	}
 
 	if dryRun {

--- a/glx/merge_runner_test.go
+++ b/glx/merge_runner_test.go
@@ -49,7 +49,7 @@ func TestMergeArchives_NewEntities(t *testing.T) {
 
 	result := mergeArchivesInMemory(dest, src)
 
-	assert.Empty(t, result.Conflicts, "no duplicates expected")
+	assert.Empty(t, result.Conflicts, "no conflicts expected")
 	assert.Equal(t, 1, result.NewPersons)
 	assert.Equal(t, 1, result.NewEvents)
 	assert.Len(t, dest.Persons, 2)

--- a/glx/merge_runner_test.go
+++ b/glx/merge_runner_test.go
@@ -49,7 +49,7 @@ func TestMergeArchives_NewEntities(t *testing.T) {
 
 	result := mergeArchivesInMemory(dest, src)
 
-	assert.Empty(t, result.Duplicates, "no duplicates expected")
+	assert.Empty(t, result.Conflicts, "no duplicates expected")
 	assert.Equal(t, 1, result.NewPersons)
 	assert.Equal(t, 1, result.NewEvents)
 	assert.Len(t, dest.Persons, 2)
@@ -73,8 +73,8 @@ func TestMergeArchives_Duplicates(t *testing.T) {
 
 	result := mergeArchivesInMemory(dest, src)
 
-	require.Len(t, result.Duplicates, 1)
-	assert.Contains(t, result.Duplicates[0], "person-a")
+	require.Len(t, result.Conflicts, 1)
+	assert.Contains(t, result.Conflicts[0], "person-a")
 	assert.Equal(t, 1, result.NewPersons)
 }
 
@@ -89,7 +89,7 @@ func TestMergeArchives_EmptySource(t *testing.T) {
 
 	result := mergeArchivesInMemory(dest, src)
 
-	assert.Empty(t, result.Duplicates)
+	assert.Empty(t, result.Conflicts)
 	assert.Equal(t, 0, result.TotalNew())
 	assert.Len(t, dest.Persons, 1)
 }

--- a/glx/merge_runner_test.go
+++ b/glx/merge_runner_test.go
@@ -56,7 +56,7 @@ func TestMergeArchives_NewEntities(t *testing.T) {
 	assert.Contains(t, dest.Persons, "person-b")
 }
 
-func TestMergeArchives_Duplicates(t *testing.T) {
+func TestMergeArchives_Conflicts(t *testing.T) {
 	dest := &glxlib.GLXFile{
 		Persons: map[string]*glxlib.Person{
 			"person-a": {Properties: map[string]any{"name": "Person A"}},

--- a/go-glx/serializer.go
+++ b/go-glx/serializer.go
@@ -301,7 +301,7 @@ func (s *DefaultSerializer) DeserializeMultiFileFromMap(files map[string][]byte)
 		if err := yaml.Unmarshal(data, &partial); err != nil {
 			return nil, nil, fmt.Errorf("failed to unmarshal %s: %w", path, err)
 		}
-		duplicates := glx.Merge(&partial)
+		duplicates, _ := glx.Merge(&partial)
 		allDuplicates = append(allDuplicates, duplicates...)
 	}
 

--- a/go-glx/serializer.go
+++ b/go-glx/serializer.go
@@ -287,7 +287,7 @@ func (s *DefaultSerializer) DeserializeMultiFileFromMap(files map[string][]byte)
 		SourceProperties:       make(map[string]*PropertyDefinition),
 	}
 
-	var allDuplicates []string
+	var allConflicts []string
 
 	// Each file is a GLXFile fragment — the YAML top-level keys (persons:,
 	// events:, event_types:, etc.) determine what entities it contains,
@@ -301,8 +301,8 @@ func (s *DefaultSerializer) DeserializeMultiFileFromMap(files map[string][]byte)
 		if err := yaml.Unmarshal(data, &partial); err != nil {
 			return nil, nil, fmt.Errorf("failed to unmarshal %s: %w", path, err)
 		}
-		duplicates, _ := glx.Merge(&partial)
-		allDuplicates = append(allDuplicates, duplicates...)
+		conflicts, _ := glx.Merge(&partial)
+		allConflicts = append(allConflicts, conflicts...)
 	}
 
 	// Validate if requested
@@ -312,7 +312,7 @@ func (s *DefaultSerializer) DeserializeMultiFileFromMap(files map[string][]byte)
 		}
 	}
 
-	return glx, allDuplicates, nil
+	return glx, allConflicts, nil
 }
 
 // validateGLXFile validates a GLX archive using the built-in validation system.

--- a/go-glx/types.go
+++ b/go-glx/types.go
@@ -399,9 +399,9 @@ type TemporalValue struct {
 }
 
 // Merge combines another GLXFile into this one, returning conflict messages and
-// a count of identical items silently skipped. Entity duplicates (same ID,
-// regardless of value) are always reported as conflicts. Vocabulary/property
-// duplicates are only reported when the values differ; identical vocabulary
+// a count of identical items silently skipped. Entity conflicts (same ID,
+// regardless of value) are always reported. Vocabulary/property conflicts
+// are only reported when the values differ; identical vocabulary
 // entries (e.g., standard vocabularies present in both archives) are silently
 // skipped and counted.
 func (g *GLXFile) Merge(other *GLXFile) (conflicts []string, identicalSkipped int) {
@@ -409,7 +409,7 @@ func (g *GLXFile) Merge(other *GLXFile) (conflicts []string, identicalSkipped in
 	g.validation = nil // invalidate cached validation since maps are being mutated
 	conflicts = make([]string, 0, 10)
 
-	// Merge metadata (first one wins; report duplicate if both have content)
+	// Merge metadata (first one wins; report conflict if both have content)
 	if other.ImportMetadata != nil && other.ImportMetadata.hasContent() {
 		if g.ImportMetadata != nil && g.ImportMetadata.hasContent() {
 			conflicts = append(conflicts, "conflict metadata: metadata appears in multiple files")
@@ -418,7 +418,7 @@ func (g *GLXFile) Merge(other *GLXFile) (conflicts []string, identicalSkipped in
 		}
 	}
 
-	// Merge entities — always report duplicates (entity ID collisions are significant)
+	// Merge entities — always report conflicts (entity ID collisions are significant)
 	conflicts = append(conflicts, mergeMap("persons", g.Persons, other.Persons)...)
 	conflicts = append(conflicts, mergeMap("relationships", g.Relationships, other.Relationships)...)
 	conflicts = append(conflicts, mergeMap("events", g.Events, other.Events)...)

--- a/go-glx/types.go
+++ b/go-glx/types.go
@@ -15,8 +15,10 @@
 package glx
 
 import (
-	"encoding/json"
+	"bytes"
 	"fmt"
+
+	"gopkg.in/yaml.v3"
 )
 
 // Metadata holds import metadata extracted from GEDCOM HEAD and SUBM records.
@@ -562,15 +564,16 @@ func mergeMap[T any](mapType string, dest, src map[string]*T) []string {
 
 // mergeMapDedup merges src into dest, silently skipping entries where the key
 // exists and the value is semantically equal. Only reports conflicts where the
-// same key maps to a different value. Uses JSON marshaling for comparison so
-// that nil maps and empty maps are treated as equivalent.
+// same key maps to a different value. Uses YAML marshaling for comparison so
+// that nil maps/slices and empty maps/slices are treated as equivalent (both
+// omitted by omitempty tags).
 func mergeMapDedup[T any](mapType string, dest, src map[string]*T) (conflicts []string, skipped int) {
 	if dest == nil || src == nil {
 		return nil, 0
 	}
 	for k, v := range src {
 		if existing, exists := dest[k]; exists {
-			if jsonEqual(existing, v) {
+			if yamlEqual(existing, v) {
 				skipped++
 			} else {
 				conflicts = append(conflicts, fmt.Sprintf("conflict %s ID: %s", mapType, k))
@@ -583,14 +586,14 @@ func mergeMapDedup[T any](mapType string, dest, src map[string]*T) (conflicts []
 	return conflicts, skipped
 }
 
-// jsonEqual compares two values by JSON-marshaling both, treating nil maps/slices
-// and empty maps/slices as equivalent.
-func jsonEqual(a, b any) bool {
-	aj, err1 := json.Marshal(a)
-	bj, err2 := json.Marshal(b)
+// yamlEqual compares two values by YAML-marshaling both. This correctly treats
+// nil and empty maps/slices as equivalent because the struct tags use omitempty.
+func yamlEqual(a, b any) bool {
+	ay, err1 := yaml.Marshal(a)
+	by, err2 := yaml.Marshal(b)
 	if err1 != nil || err2 != nil {
 		return false
 	}
 
-	return string(aj) == string(bj)
+	return bytes.Equal(ay, by)
 }

--- a/go-glx/types.go
+++ b/go-glx/types.go
@@ -372,9 +372,9 @@ type GenderType struct {
 // PropertyDefinition defines a property that can be used on entities.
 // value_type, reference_type, and vocabulary_type are mutually exclusive.
 type PropertyDefinition struct {
-	Label         string                      `yaml:"label"`
-	Description   string                      `yaml:"description,omitempty"`
-	GEDCOM        string                      `yaml:"gedcom,omitempty"`
+	Label          string                      `yaml:"label"`
+	Description    string                      `yaml:"description,omitempty"`
+	GEDCOM         string                      `yaml:"gedcom,omitempty"`
 	ValueType      string                      `yaml:"value_type,omitempty"`      // string, date, integer, boolean
 	ReferenceType  string                      `yaml:"reference_type,omitempty"`  // persons, places, events, relationships, etc.
 	VocabularyType string                      `yaml:"vocabulary_type,omitempty"` // Value must exist in this vocabulary (e.g., gender_types)
@@ -392,7 +392,7 @@ type FieldDefinition struct {
 // TemporalValue represents a single entry in the history of a temporal property.
 // It is used when a temporal property is represented as a list.
 type TemporalValue struct {
-	Value any    `yaml:"value"`
+	Value any        `yaml:"value"`
 	Date  DateString `yaml:"date,omitempty"` // FamilySearch normalized date string
 }
 
@@ -578,5 +578,6 @@ func mergeMapDedup[T any](mapType string, dest, src map[string]*T) (conflicts []
 			dest[k] = v
 		}
 	}
+
 	return conflicts, skipped
 }

--- a/go-glx/types.go
+++ b/go-glx/types.go
@@ -15,8 +15,8 @@
 package glx
 
 import (
+	"encoding/json"
 	"fmt"
-	"reflect"
 )
 
 // Metadata holds import metadata extracted from GEDCOM HEAD and SUBM records.
@@ -410,7 +410,7 @@ func (g *GLXFile) Merge(other *GLXFile) (conflicts []string, identicalSkipped in
 	// Merge metadata (first one wins; report duplicate if both have content)
 	if other.ImportMetadata != nil && other.ImportMetadata.hasContent() {
 		if g.ImportMetadata != nil && g.ImportMetadata.hasContent() {
-			conflicts = append(conflicts, "duplicate metadata: metadata appears in multiple files")
+			conflicts = append(conflicts, "conflict metadata: metadata appears in multiple files")
 		} else {
 			g.ImportMetadata = other.ImportMetadata
 		}
@@ -542,34 +542,35 @@ func (g *GLXFile) initMaps() {
 	}
 }
 
-// mergeMap merges src into dest, reporting all key collisions as duplicates.
+// mergeMap merges src into dest, reporting all key collisions as conflicts.
 // Used for entity maps where any ID collision is significant.
 func mergeMap[T any](mapType string, dest, src map[string]*T) []string {
-	var duplicates []string
+	var conflicts []string
 	if dest == nil || src == nil {
-		return duplicates
+		return conflicts
 	}
 	for k, v := range src {
 		if _, exists := dest[k]; exists {
-			duplicates = append(duplicates, fmt.Sprintf("duplicate %s ID: %s", mapType, k))
+			conflicts = append(conflicts, fmt.Sprintf("conflict %s ID: %s", mapType, k))
 		} else {
 			dest[k] = v
 		}
 	}
-	return duplicates
+
+	return conflicts
 }
 
 // mergeMapDedup merges src into dest, silently skipping entries where the key
-// exists and the value is deeply equal. Only reports conflicts where the same
-// key maps to a different value. Used for vocabulary/property maps where
-// identical standard vocabularies in both archives should not produce noise.
+// exists and the value is semantically equal. Only reports conflicts where the
+// same key maps to a different value. Uses JSON marshaling for comparison so
+// that nil maps and empty maps are treated as equivalent.
 func mergeMapDedup[T any](mapType string, dest, src map[string]*T) (conflicts []string, skipped int) {
 	if dest == nil || src == nil {
 		return nil, 0
 	}
 	for k, v := range src {
 		if existing, exists := dest[k]; exists {
-			if reflect.DeepEqual(existing, v) {
+			if jsonEqual(existing, v) {
 				skipped++
 			} else {
 				conflicts = append(conflicts, fmt.Sprintf("conflict %s ID: %s", mapType, k))
@@ -580,4 +581,16 @@ func mergeMapDedup[T any](mapType string, dest, src map[string]*T) (conflicts []
 	}
 
 	return conflicts, skipped
+}
+
+// jsonEqual compares two values by JSON-marshaling both, treating nil maps/slices
+// and empty maps/slices as equivalent.
+func jsonEqual(a, b any) bool {
+	aj, err1 := json.Marshal(a)
+	bj, err2 := json.Marshal(b)
+	if err1 != nil || err2 != nil {
+		return false
+	}
+
+	return string(aj) == string(bj)
 }

--- a/go-glx/types.go
+++ b/go-glx/types.go
@@ -16,6 +16,7 @@ package glx
 
 import (
 	"fmt"
+	"reflect"
 )
 
 // Metadata holds import metadata extracted from GEDCOM HEAD and SUBM records.
@@ -395,56 +396,65 @@ type TemporalValue struct {
 	Date  DateString `yaml:"date,omitempty"` // FamilySearch normalized date string
 }
 
-// Merge combines another GLXFile into this one, returning duplicate/conflict messages.
-// Messages may report duplicate entity or vocabulary IDs ("duplicate <type> ID: <id>")
-// or metadata conflicts ("duplicate metadata: ...").
-func (g *GLXFile) Merge(other *GLXFile) []string {
+// Merge combines another GLXFile into this one, returning conflict messages and
+// a count of identical items silently skipped. Entity duplicates (same ID,
+// regardless of value) are always reported as conflicts. Vocabulary/property
+// duplicates are only reported when the values differ; identical vocabulary
+// entries (e.g., standard vocabularies present in both archives) are silently
+// skipped and counted.
+func (g *GLXFile) Merge(other *GLXFile) (conflicts []string, identicalSkipped int) {
 	g.initMaps()
 	g.validation = nil // invalidate cached validation since maps are being mutated
-	duplicates := make([]string, 0, 10)
+	conflicts = make([]string, 0, 10)
 
 	// Merge metadata (first one wins; report duplicate if both have content)
 	if other.ImportMetadata != nil && other.ImportMetadata.hasContent() {
 		if g.ImportMetadata != nil && g.ImportMetadata.hasContent() {
-			duplicates = append(duplicates, "duplicate metadata: metadata appears in multiple files")
+			conflicts = append(conflicts, "duplicate metadata: metadata appears in multiple files")
 		} else {
 			g.ImportMetadata = other.ImportMetadata
 		}
 	}
 
-	// Merge entities (fail on duplicates)
-	duplicates = append(duplicates, mergeMap("persons", g.Persons, other.Persons)...)
-	duplicates = append(duplicates, mergeMap("relationships", g.Relationships, other.Relationships)...)
-	duplicates = append(duplicates, mergeMap("events", g.Events, other.Events)...)
-	duplicates = append(duplicates, mergeMap("places", g.Places, other.Places)...)
-	duplicates = append(duplicates, mergeMap("sources", g.Sources, other.Sources)...)
-	duplicates = append(duplicates, mergeMap("citations", g.Citations, other.Citations)...)
-	duplicates = append(duplicates, mergeMap("repositories", g.Repositories, other.Repositories)...)
-	duplicates = append(duplicates, mergeMap("assertions", g.Assertions, other.Assertions)...)
-	duplicates = append(duplicates, mergeMap("media", g.Media, other.Media)...)
+	// Merge entities — always report duplicates (entity ID collisions are significant)
+	conflicts = append(conflicts, mergeMap("persons", g.Persons, other.Persons)...)
+	conflicts = append(conflicts, mergeMap("relationships", g.Relationships, other.Relationships)...)
+	conflicts = append(conflicts, mergeMap("events", g.Events, other.Events)...)
+	conflicts = append(conflicts, mergeMap("places", g.Places, other.Places)...)
+	conflicts = append(conflicts, mergeMap("sources", g.Sources, other.Sources)...)
+	conflicts = append(conflicts, mergeMap("citations", g.Citations, other.Citations)...)
+	conflicts = append(conflicts, mergeMap("repositories", g.Repositories, other.Repositories)...)
+	conflicts = append(conflicts, mergeMap("assertions", g.Assertions, other.Assertions)...)
+	conflicts = append(conflicts, mergeMap("media", g.Media, other.Media)...)
 
-	// Merge vocabularies (ALSO fail on duplicates - treat same as entities)
-	duplicates = append(duplicates, mergeMap("event_types", g.EventTypes, other.EventTypes)...)
-	duplicates = append(duplicates, mergeMap("relationship_types", g.RelationshipTypes, other.RelationshipTypes)...)
-	duplicates = append(duplicates, mergeMap("place_types", g.PlaceTypes, other.PlaceTypes)...)
-	duplicates = append(duplicates, mergeMap("source_types", g.SourceTypes, other.SourceTypes)...)
-	duplicates = append(duplicates, mergeMap("repository_types", g.RepositoryTypes, other.RepositoryTypes)...)
-	duplicates = append(duplicates, mergeMap("media_types", g.MediaTypes, other.MediaTypes)...)
-	duplicates = append(duplicates, mergeMap("gender_types", g.GenderTypes, other.GenderTypes)...)
-	duplicates = append(duplicates, mergeMap("participant_roles", g.ParticipantRoles, other.ParticipantRoles)...)
-	duplicates = append(duplicates, mergeMap("confidence_levels", g.ConfidenceLevels, other.ConfidenceLevels)...)
+	// Helper to accumulate mergeMapDedup results
+	addDedup := func(c []string, s int) {
+		conflicts = append(conflicts, c...)
+		identicalSkipped += s
+	}
 
-	// Merge property vocabularies
-	duplicates = append(duplicates, mergeMap("person_properties", g.PersonProperties, other.PersonProperties)...)
-	duplicates = append(duplicates, mergeMap("event_properties", g.EventProperties, other.EventProperties)...)
-	duplicates = append(duplicates, mergeMap("relationship_properties", g.RelationshipProperties, other.RelationshipProperties)...)
-	duplicates = append(duplicates, mergeMap("place_properties", g.PlaceProperties, other.PlaceProperties)...)
-	duplicates = append(duplicates, mergeMap("media_properties", g.MediaProperties, other.MediaProperties)...)
-	duplicates = append(duplicates, mergeMap("repository_properties", g.RepositoryProperties, other.RepositoryProperties)...)
-	duplicates = append(duplicates, mergeMap("citation_properties", g.CitationProperties, other.CitationProperties)...)
-	duplicates = append(duplicates, mergeMap("source_properties", g.SourceProperties, other.SourceProperties)...)
+	// Merge vocabularies — silently skip identical entries, report only true conflicts
+	addDedup(mergeMapDedup("event_types", g.EventTypes, other.EventTypes))
+	addDedup(mergeMapDedup("relationship_types", g.RelationshipTypes, other.RelationshipTypes))
+	addDedup(mergeMapDedup("place_types", g.PlaceTypes, other.PlaceTypes))
+	addDedup(mergeMapDedup("source_types", g.SourceTypes, other.SourceTypes))
+	addDedup(mergeMapDedup("repository_types", g.RepositoryTypes, other.RepositoryTypes))
+	addDedup(mergeMapDedup("media_types", g.MediaTypes, other.MediaTypes))
+	addDedup(mergeMapDedup("gender_types", g.GenderTypes, other.GenderTypes))
+	addDedup(mergeMapDedup("participant_roles", g.ParticipantRoles, other.ParticipantRoles))
+	addDedup(mergeMapDedup("confidence_levels", g.ConfidenceLevels, other.ConfidenceLevels))
 
-	return duplicates
+	// Merge property vocabularies — same dedup behavior
+	addDedup(mergeMapDedup("person_properties", g.PersonProperties, other.PersonProperties))
+	addDedup(mergeMapDedup("event_properties", g.EventProperties, other.EventProperties))
+	addDedup(mergeMapDedup("relationship_properties", g.RelationshipProperties, other.RelationshipProperties))
+	addDedup(mergeMapDedup("place_properties", g.PlaceProperties, other.PlaceProperties))
+	addDedup(mergeMapDedup("media_properties", g.MediaProperties, other.MediaProperties))
+	addDedup(mergeMapDedup("repository_properties", g.RepositoryProperties, other.RepositoryProperties))
+	addDedup(mergeMapDedup("citation_properties", g.CitationProperties, other.CitationProperties))
+	addDedup(mergeMapDedup("source_properties", g.SourceProperties, other.SourceProperties))
+
+	return conflicts, identicalSkipped
 }
 
 // initMaps ensures all entity and vocabulary maps are initialized (non-nil).
@@ -532,13 +542,11 @@ func (g *GLXFile) initMaps() {
 	}
 }
 
-// mergeMap is used for BOTH entities and vocabularies - duplicates are always errors
+// mergeMap merges src into dest, reporting all key collisions as duplicates.
+// Used for entity maps where any ID collision is significant.
 func mergeMap[T any](mapType string, dest, src map[string]*T) []string {
 	var duplicates []string
-	if dest == nil {
-		return duplicates
-	}
-	if src == nil {
+	if dest == nil || src == nil {
 		return duplicates
 	}
 	for k, v := range src {
@@ -548,6 +556,27 @@ func mergeMap[T any](mapType string, dest, src map[string]*T) []string {
 			dest[k] = v
 		}
 	}
-
 	return duplicates
+}
+
+// mergeMapDedup merges src into dest, silently skipping entries where the key
+// exists and the value is deeply equal. Only reports conflicts where the same
+// key maps to a different value. Used for vocabulary/property maps where
+// identical standard vocabularies in both archives should not produce noise.
+func mergeMapDedup[T any](mapType string, dest, src map[string]*T) (conflicts []string, skipped int) {
+	if dest == nil || src == nil {
+		return nil, 0
+	}
+	for k, v := range src {
+		if existing, exists := dest[k]; exists {
+			if reflect.DeepEqual(existing, v) {
+				skipped++
+			} else {
+				conflicts = append(conflicts, fmt.Sprintf("conflict %s ID: %s", mapType, k))
+			}
+		} else {
+			dest[k] = v
+		}
+	}
+	return conflicts, skipped
 }

--- a/go-glx/types_merge_test.go
+++ b/go-glx/types_merge_test.go
@@ -26,7 +26,7 @@ func TestGLXFile_Merge_EmptyFiles(t *testing.T) {
 	g1 := &GLXFile{}
 	g2 := &GLXFile{}
 
-	duplicates := g1.Merge(g2)
+	duplicates, _ := g1.Merge(g2)
 	require.Empty(t, duplicates, "merging empty files should have no duplicates")
 }
 
@@ -45,7 +45,7 @@ func TestGLXFile_Merge_NilDestMaps(t *testing.T) {
 		},
 	}
 
-	duplicates := g1.Merge(g2)
+	duplicates, _ := g1.Merge(g2)
 	require.Empty(t, duplicates, "should have no duplicates")
 	require.Len(t, g1.Persons, 1, "persons should be merged into initialized map")
 	require.Len(t, g1.Events, 1, "events should be merged into initialized map")
@@ -66,7 +66,7 @@ func TestGLXFile_Merge_Persons_NoDuplicates(t *testing.T) {
 		},
 	}
 
-	duplicates := g1.Merge(g2)
+	duplicates, _ := g1.Merge(g2)
 	require.Empty(t, duplicates, "should have no duplicates")
 	require.Len(t, g1.Persons, 2, "should have merged both persons")
 	require.Contains(t, g1.Persons, "person-1")
@@ -87,7 +87,7 @@ func TestGLXFile_Merge_Persons_WithDuplicates(t *testing.T) {
 		},
 	}
 
-	duplicates := g1.Merge(g2)
+	duplicates, _ := g1.Merge(g2)
 	require.Len(t, duplicates, 1, "should detect one duplicate")
 	require.Contains(t, duplicates[0], "duplicate persons ID: person-1")
 
@@ -122,7 +122,7 @@ func TestGLXFile_Merge_AllEntityTypes(t *testing.T) {
 		Media:         map[string]*Media{"media-2": {}},
 	}
 
-	duplicates := g1.Merge(g2)
+	duplicates, _ := g1.Merge(g2)
 	require.Empty(t, duplicates, "should have no duplicates")
 
 	// Verify all entity types were merged
@@ -157,7 +157,7 @@ func TestGLXFile_Merge_Vocabularies_NoDuplicates(t *testing.T) {
 		},
 	}
 
-	duplicates := g1.Merge(g2)
+	duplicates, _ := g1.Merge(g2)
 	require.Empty(t, duplicates, "should have no duplicates")
 	require.Len(t, g1.EventTypes, 2)
 	require.Len(t, g1.ParticipantRoles, 2)
@@ -178,9 +178,9 @@ func TestGLXFile_Merge_Vocabularies_WithDuplicates(t *testing.T) {
 		},
 	}
 
-	duplicates := g1.Merge(g2)
-	require.Len(t, duplicates, 1, "should detect one duplicate")
-	require.Contains(t, duplicates[0], "duplicate event_types ID: birth")
+	duplicates, _ := g1.Merge(g2)
+	require.Len(t, duplicates, 1, "should detect one conflict")
+	require.Contains(t, duplicates[0], "conflict event_types ID: birth")
 
 	// death should still be merged
 	require.Len(t, g1.EventTypes, 2)
@@ -213,7 +213,7 @@ func TestGLXFile_Merge_AllVocabularyTypes(t *testing.T) {
 		GenderTypes:       map[string]*GenderType{"gender-2": {}},
 	}
 
-	duplicates := g1.Merge(g2)
+	duplicates, _ := g1.Merge(g2)
 	require.Empty(t, duplicates, "should have no duplicates")
 
 	// Verify all vocabulary types were merged
@@ -248,7 +248,7 @@ func TestGLXFile_Merge_PropertyVocabularies_NoDuplicates(t *testing.T) {
 		},
 	}
 
-	duplicates := g1.Merge(g2)
+	duplicates, _ := g1.Merge(g2)
 	require.Empty(t, duplicates, "should have no duplicates")
 	require.Len(t, g1.PersonProperties, 2)
 	require.Len(t, g1.EventProperties, 2)
@@ -269,9 +269,9 @@ func TestGLXFile_Merge_PropertyVocabularies_WithDuplicates(t *testing.T) {
 		},
 	}
 
-	duplicates := g1.Merge(g2)
-	require.Len(t, duplicates, 1, "should detect one duplicate")
-	require.Contains(t, duplicates[0], "duplicate person_properties ID: prop-1")
+	duplicates, _ := g1.Merge(g2)
+	require.Len(t, duplicates, 1, "should detect one conflict")
+	require.Contains(t, duplicates[0], "conflict person_properties ID: prop-1")
 
 	// prop-2 should still be merged
 	require.Len(t, g1.PersonProperties, 2)
@@ -294,7 +294,7 @@ func TestGLXFile_Merge_AllPropertyVocabularies(t *testing.T) {
 		PlaceProperties:        map[string]*PropertyDefinition{"prop-2": {}},
 	}
 
-	duplicates := g1.Merge(g2)
+	duplicates, _ := g1.Merge(g2)
 	require.Empty(t, duplicates, "should have no duplicates")
 
 	// Verify all property vocabulary types were merged
@@ -333,10 +333,11 @@ func TestGLXFile_Merge_MultipleDuplicates(t *testing.T) {
 		},
 	}
 
-	duplicates := g1.Merge(g2)
-	require.Len(t, duplicates, 3, "should detect three duplicates")
+	duplicates, skipped := g1.Merge(g2)
+	require.Len(t, duplicates, 2, "should detect two entity duplicates")
+	require.Equal(t, 1, skipped, "should silently skip one identical vocab entry")
 
-	// Check that all duplicates are reported
+	// Check that entity duplicates are reported
 	duplicateStr := ""
 	var duplicateStrSb317 strings.Builder
 	for _, d := range duplicates {
@@ -345,7 +346,6 @@ func TestGLXFile_Merge_MultipleDuplicates(t *testing.T) {
 	duplicateStr += duplicateStrSb317.String()
 	require.Contains(t, duplicateStr, "person-1")
 	require.Contains(t, duplicateStr, "event-1")
-	require.Contains(t, duplicateStr, "birth")
 
 	// Non-duplicates should still be merged
 	require.Contains(t, g1.Persons, "person-2")
@@ -369,7 +369,7 @@ func TestGLXFile_Merge_NilMaps(t *testing.T) {
 		},
 	}
 
-	duplicates := g1.Merge(g2)
+	duplicates, _ := g1.Merge(g2)
 	require.Empty(t, duplicates, "should have no duplicates")
 
 	// nil dest maps should be initialized and populated with source data
@@ -395,7 +395,7 @@ func TestGLXFile_Merge_SourceNilMaps(t *testing.T) {
 		Events:  nil,
 	}
 
-	duplicates := g1.Merge(g2)
+	duplicates, _ := g1.Merge(g2)
 	require.Empty(t, duplicates, "should have no duplicates")
 
 	// Destination should remain unchanged
@@ -437,7 +437,7 @@ func TestGLXFile_Merge_MixedEntitiesAndVocabularies(t *testing.T) {
 		},
 	}
 
-	duplicates := g1.Merge(g2)
+	duplicates, _ := g1.Merge(g2)
 	require.Empty(t, duplicates, "should have no duplicates")
 
 	// Verify everything merged correctly
@@ -462,7 +462,7 @@ func TestGLXFile_Merge_PreservesExistingData(t *testing.T) {
 		},
 	}
 
-	duplicates := g1.Merge(g2)
+	duplicates, _ := g1.Merge(g2)
 	require.Empty(t, duplicates)
 
 	// Verify original data is preserved
@@ -496,7 +496,7 @@ func TestGLXFile_Merge_DuplicateReporting(t *testing.T) {
 		Media:         map[string]*Media{"media-1": {}},
 	}
 
-	duplicates := g1.Merge(g2)
+	duplicates, _ := g1.Merge(g2)
 	require.Len(t, duplicates, 9, "should detect 9 duplicates")
 
 	// Verify messages include the entity type and ID
@@ -530,7 +530,7 @@ func TestGLXFile_Merge_Metadata_AdoptFromOther(t *testing.T) {
 		},
 	}
 
-	duplicates := g1.Merge(g2)
+	duplicates, _ := g1.Merge(g2)
 	require.Empty(t, duplicates, "should have no duplicates")
 	require.NotNil(t, g1.ImportMetadata, "metadata should be adopted from other")
 	require.Equal(t, "MyApp", g1.ImportMetadata.SourceSystem)
@@ -551,7 +551,7 @@ func TestGLXFile_Merge_Metadata_DuplicateDetected(t *testing.T) {
 		},
 	}
 
-	duplicates := g1.Merge(g2)
+	duplicates, _ := g1.Merge(g2)
 	require.Len(t, duplicates, 1, "should detect one metadata duplicate")
 	require.Contains(t, duplicates[0], "duplicate metadata")
 
@@ -568,7 +568,7 @@ func TestGLXFile_Merge_Metadata_EmptyMetadataIgnored(t *testing.T) {
 		ImportMetadata: &Metadata{}, // all fields empty
 	}
 
-	duplicates := g1.Merge(g2)
+	duplicates, _ := g1.Merge(g2)
 	require.Empty(t, duplicates, "should have no duplicates")
 	require.Nil(t, g1.ImportMetadata, "empty metadata should not be adopted")
 }
@@ -582,7 +582,7 @@ func TestGLXFile_Merge_Metadata_NilMetadataBothSides(t *testing.T) {
 		Persons: map[string]*Person{},
 	}
 
-	duplicates := g1.Merge(g2)
+	duplicates, _ := g1.Merge(g2)
 	require.Empty(t, duplicates)
 	require.Nil(t, g1.ImportMetadata)
 }
@@ -600,8 +600,66 @@ func TestGLXFile_Merge_Metadata_ExistingEmptyDoesNotConflict(t *testing.T) {
 		},
 	}
 
-	duplicates := g1.Merge(g2)
+	duplicates, _ := g1.Merge(g2)
 	require.Empty(t, duplicates, "should have no duplicates since g1 metadata has no content")
 	require.NotNil(t, g1.ImportMetadata)
 	require.Equal(t, "NewApp", g1.ImportMetadata.SourceSystem)
+}
+
+func TestGLXFile_Merge_IdenticalVocabsSilentlySkipped(t *testing.T) {
+	g1 := &GLXFile{
+		EventTypes: map[string]*EventType{
+			"birth": {Label: "Birth", Description: "A birth event"},
+			"death": {Label: "Death"},
+		},
+		PersonProperties: map[string]*PropertyDefinition{
+			"name": {ValueType: "string", Label: "Name"},
+		},
+	}
+
+	g2 := &GLXFile{
+		EventTypes: map[string]*EventType{
+			"birth":    {Label: "Birth", Description: "A birth event"},
+			"death":    {Label: "Death"},
+			"marriage": {Label: "Marriage"},
+		},
+		PersonProperties: map[string]*PropertyDefinition{
+			"name": {ValueType: "string", Label: "Name"},
+			"age":  {ValueType: "integer"},
+		},
+	}
+
+	conflicts, skipped := g1.Merge(g2)
+	require.Empty(t, conflicts, "identical entries should not produce conflicts")
+	require.Equal(t, 3, skipped, "should skip 3 identical entries (birth, death, name)")
+	require.Len(t, g1.EventTypes, 3)
+	require.Contains(t, g1.EventTypes, "marriage")
+	require.Len(t, g1.PersonProperties, 2)
+	require.Contains(t, g1.PersonProperties, "age")
+}
+
+func TestGLXFile_Merge_ConflictingVocabsReported(t *testing.T) {
+	g1 := &GLXFile{
+		EventTypes: map[string]*EventType{
+			"birth": {Label: "Birth"},
+		},
+		PersonProperties: map[string]*PropertyDefinition{
+			"name": {ValueType: "string"},
+		},
+	}
+
+	g2 := &GLXFile{
+		EventTypes: map[string]*EventType{
+			"birth": {Label: "Different Birth"},
+		},
+		PersonProperties: map[string]*PropertyDefinition{
+			"name": {ValueType: "integer"},
+		},
+	}
+
+	conflicts, skipped := g1.Merge(g2)
+	require.Len(t, conflicts, 2, "should report two conflicts")
+	require.Equal(t, 0, skipped, "no identical entries to skip")
+	require.Contains(t, conflicts[0], "conflict")
+	require.Contains(t, conflicts[1], "conflict")
 }

--- a/go-glx/types_merge_test.go
+++ b/go-glx/types_merge_test.go
@@ -26,8 +26,8 @@ func TestGLXFile_Merge_EmptyFiles(t *testing.T) {
 	g1 := &GLXFile{}
 	g2 := &GLXFile{}
 
-	duplicates, _ := g1.Merge(g2)
-	require.Empty(t, duplicates, "merging empty files should have no duplicates")
+	conflicts, _ := g1.Merge(g2)
+	require.Empty(t, conflicts, "merging empty files should have no duplicates")
 }
 
 func TestGLXFile_Merge_NilDestMaps(t *testing.T) {
@@ -45,8 +45,8 @@ func TestGLXFile_Merge_NilDestMaps(t *testing.T) {
 		},
 	}
 
-	duplicates, _ := g1.Merge(g2)
-	require.Empty(t, duplicates, "should have no duplicates")
+	conflicts, _ := g1.Merge(g2)
+	require.Empty(t, conflicts, "should have no duplicates")
 	require.Len(t, g1.Persons, 1, "persons should be merged into initialized map")
 	require.Len(t, g1.Events, 1, "events should be merged into initialized map")
 	require.Len(t, g1.Places, 1, "places should be merged into initialized map")
@@ -66,8 +66,8 @@ func TestGLXFile_Merge_Persons_NoDuplicates(t *testing.T) {
 		},
 	}
 
-	duplicates, _ := g1.Merge(g2)
-	require.Empty(t, duplicates, "should have no duplicates")
+	conflicts, _ := g1.Merge(g2)
+	require.Empty(t, conflicts, "should have no duplicates")
 	require.Len(t, g1.Persons, 2, "should have merged both persons")
 	require.Contains(t, g1.Persons, "person-1")
 	require.Contains(t, g1.Persons, "person-2")
@@ -87,9 +87,9 @@ func TestGLXFile_Merge_Persons_WithDuplicates(t *testing.T) {
 		},
 	}
 
-	duplicates, _ := g1.Merge(g2)
-	require.Len(t, duplicates, 1, "should detect one duplicate")
-	require.Contains(t, duplicates[0], "duplicate persons ID: person-1")
+	conflicts, _ := g1.Merge(g2)
+	require.Len(t, conflicts, 1, "should detect one duplicate")
+	require.Contains(t, conflicts[0], "duplicate persons ID: person-1")
 
 	// person-2 should still be merged
 	require.Len(t, g1.Persons, 2, "should merge non-duplicate persons")
@@ -122,8 +122,8 @@ func TestGLXFile_Merge_AllEntityTypes(t *testing.T) {
 		Media:         map[string]*Media{"media-2": {}},
 	}
 
-	duplicates, _ := g1.Merge(g2)
-	require.Empty(t, duplicates, "should have no duplicates")
+	conflicts, _ := g1.Merge(g2)
+	require.Empty(t, conflicts, "should have no duplicates")
 
 	// Verify all entity types were merged
 	require.Len(t, g1.Persons, 2)
@@ -157,8 +157,8 @@ func TestGLXFile_Merge_Vocabularies_NoDuplicates(t *testing.T) {
 		},
 	}
 
-	duplicates, _ := g1.Merge(g2)
-	require.Empty(t, duplicates, "should have no duplicates")
+	conflicts, _ := g1.Merge(g2)
+	require.Empty(t, conflicts, "should have no duplicates")
 	require.Len(t, g1.EventTypes, 2)
 	require.Len(t, g1.ParticipantRoles, 2)
 }
@@ -178,9 +178,9 @@ func TestGLXFile_Merge_Vocabularies_WithDuplicates(t *testing.T) {
 		},
 	}
 
-	duplicates, _ := g1.Merge(g2)
-	require.Len(t, duplicates, 1, "should detect one conflict")
-	require.Contains(t, duplicates[0], "conflict event_types ID: birth")
+	conflicts, _ := g1.Merge(g2)
+	require.Len(t, conflicts, 1, "should detect one conflict")
+	require.Contains(t, conflicts[0], "conflict event_types ID: birth")
 
 	// death should still be merged
 	require.Len(t, g1.EventTypes, 2)
@@ -213,8 +213,8 @@ func TestGLXFile_Merge_AllVocabularyTypes(t *testing.T) {
 		GenderTypes:       map[string]*GenderType{"gender-2": {}},
 	}
 
-	duplicates, _ := g1.Merge(g2)
-	require.Empty(t, duplicates, "should have no duplicates")
+	conflicts, _ := g1.Merge(g2)
+	require.Empty(t, conflicts, "should have no duplicates")
 
 	// Verify all vocabulary types were merged
 	require.Len(t, g1.EventTypes, 2)
@@ -248,8 +248,8 @@ func TestGLXFile_Merge_PropertyVocabularies_NoDuplicates(t *testing.T) {
 		},
 	}
 
-	duplicates, _ := g1.Merge(g2)
-	require.Empty(t, duplicates, "should have no duplicates")
+	conflicts, _ := g1.Merge(g2)
+	require.Empty(t, conflicts, "should have no duplicates")
 	require.Len(t, g1.PersonProperties, 2)
 	require.Len(t, g1.EventProperties, 2)
 }
@@ -269,9 +269,9 @@ func TestGLXFile_Merge_PropertyVocabularies_WithDuplicates(t *testing.T) {
 		},
 	}
 
-	duplicates, _ := g1.Merge(g2)
-	require.Len(t, duplicates, 1, "should detect one conflict")
-	require.Contains(t, duplicates[0], "conflict person_properties ID: prop-1")
+	conflicts, _ := g1.Merge(g2)
+	require.Len(t, conflicts, 1, "should detect one conflict")
+	require.Contains(t, conflicts[0], "conflict person_properties ID: prop-1")
 
 	// prop-2 should still be merged
 	require.Len(t, g1.PersonProperties, 2)
@@ -294,8 +294,8 @@ func TestGLXFile_Merge_AllPropertyVocabularies(t *testing.T) {
 		PlaceProperties:        map[string]*PropertyDefinition{"prop-2": {}},
 	}
 
-	duplicates, _ := g1.Merge(g2)
-	require.Empty(t, duplicates, "should have no duplicates")
+	conflicts, _ := g1.Merge(g2)
+	require.Empty(t, conflicts, "should have no duplicates")
 
 	// Verify all property vocabulary types were merged
 	require.Len(t, g1.PersonProperties, 2)
@@ -333,14 +333,14 @@ func TestGLXFile_Merge_MultipleDuplicates(t *testing.T) {
 		},
 	}
 
-	duplicates, skipped := g1.Merge(g2)
-	require.Len(t, duplicates, 2, "should detect two entity duplicates")
+	conflicts, skipped := g1.Merge(g2)
+	require.Len(t, conflicts, 2, "should detect two entity duplicates")
 	require.Equal(t, 1, skipped, "should silently skip one identical vocab entry")
 
 	// Check that entity duplicates are reported
 	duplicateStr := ""
 	var duplicateStrSb317 strings.Builder
-	for _, d := range duplicates {
+	for _, d := range conflicts {
 		duplicateStrSb317.WriteString(d + " ")
 	}
 	duplicateStr += duplicateStrSb317.String()
@@ -369,8 +369,8 @@ func TestGLXFile_Merge_NilMaps(t *testing.T) {
 		},
 	}
 
-	duplicates, _ := g1.Merge(g2)
-	require.Empty(t, duplicates, "should have no duplicates")
+	conflicts, _ := g1.Merge(g2)
+	require.Empty(t, conflicts, "should have no duplicates")
 
 	// nil dest maps should be initialized and populated with source data
 	require.NotNil(t, g1.Persons)
@@ -395,8 +395,8 @@ func TestGLXFile_Merge_SourceNilMaps(t *testing.T) {
 		Events:  nil,
 	}
 
-	duplicates, _ := g1.Merge(g2)
-	require.Empty(t, duplicates, "should have no duplicates")
+	conflicts, _ := g1.Merge(g2)
+	require.Empty(t, conflicts, "should have no duplicates")
 
 	// Destination should remain unchanged
 	require.Len(t, g1.Persons, 1)
@@ -437,8 +437,8 @@ func TestGLXFile_Merge_MixedEntitiesAndVocabularies(t *testing.T) {
 		},
 	}
 
-	duplicates, _ := g1.Merge(g2)
-	require.Empty(t, duplicates, "should have no duplicates")
+	conflicts, _ := g1.Merge(g2)
+	require.Empty(t, conflicts, "should have no duplicates")
 
 	// Verify everything merged correctly
 	require.Len(t, g1.Persons, 2)
@@ -462,8 +462,8 @@ func TestGLXFile_Merge_PreservesExistingData(t *testing.T) {
 		},
 	}
 
-	duplicates, _ := g1.Merge(g2)
-	require.Empty(t, duplicates)
+	conflicts, _ := g1.Merge(g2)
+	require.Empty(t, conflicts)
 
 	// Verify original data is preserved
 	require.Equal(t, "Original Name", g1.Persons["person-1"].Properties["primary_name"])
@@ -496,13 +496,13 @@ func TestGLXFile_Merge_DuplicateReporting(t *testing.T) {
 		Media:         map[string]*Media{"media-1": {}},
 	}
 
-	duplicates, _ := g1.Merge(g2)
-	require.Len(t, duplicates, 9, "should detect 9 duplicates")
+	conflicts, _ := g1.Merge(g2)
+	require.Len(t, conflicts, 9, "should detect 9 duplicates")
 
 	// Verify messages include the entity type and ID
 	duplicateStr := ""
 	var duplicateStrSb476 strings.Builder
-	for _, d := range duplicates {
+	for _, d := range conflicts {
 		duplicateStrSb476.WriteString(d + "\n")
 	}
 	duplicateStr += duplicateStrSb476.String()
@@ -530,8 +530,8 @@ func TestGLXFile_Merge_Metadata_AdoptFromOther(t *testing.T) {
 		},
 	}
 
-	duplicates, _ := g1.Merge(g2)
-	require.Empty(t, duplicates, "should have no duplicates")
+	conflicts, _ := g1.Merge(g2)
+	require.Empty(t, conflicts, "should have no duplicates")
 	require.NotNil(t, g1.ImportMetadata, "metadata should be adopted from other")
 	require.Equal(t, "MyApp", g1.ImportMetadata.SourceSystem)
 	require.Equal(t, DateString("2026-01-15"), g1.ImportMetadata.ExportDate)
@@ -551,9 +551,9 @@ func TestGLXFile_Merge_Metadata_DuplicateDetected(t *testing.T) {
 		},
 	}
 
-	duplicates, _ := g1.Merge(g2)
-	require.Len(t, duplicates, 1, "should detect one metadata duplicate")
-	require.Contains(t, duplicates[0], "duplicate metadata")
+	conflicts, _ := g1.Merge(g2)
+	require.Len(t, conflicts, 1, "should detect one metadata duplicate")
+	require.Contains(t, conflicts[0], "duplicate metadata")
 
 	// Original metadata is preserved (first one wins)
 	require.Equal(t, "AppA", g1.ImportMetadata.SourceSystem)
@@ -568,8 +568,8 @@ func TestGLXFile_Merge_Metadata_EmptyMetadataIgnored(t *testing.T) {
 		ImportMetadata: &Metadata{}, // all fields empty
 	}
 
-	duplicates, _ := g1.Merge(g2)
-	require.Empty(t, duplicates, "should have no duplicates")
+	conflicts, _ := g1.Merge(g2)
+	require.Empty(t, conflicts, "should have no duplicates")
 	require.Nil(t, g1.ImportMetadata, "empty metadata should not be adopted")
 }
 
@@ -582,8 +582,8 @@ func TestGLXFile_Merge_Metadata_NilMetadataBothSides(t *testing.T) {
 		Persons: map[string]*Person{},
 	}
 
-	duplicates, _ := g1.Merge(g2)
-	require.Empty(t, duplicates)
+	conflicts, _ := g1.Merge(g2)
+	require.Empty(t, conflicts)
 	require.Nil(t, g1.ImportMetadata)
 }
 
@@ -600,8 +600,8 @@ func TestGLXFile_Merge_Metadata_ExistingEmptyDoesNotConflict(t *testing.T) {
 		},
 	}
 
-	duplicates, _ := g1.Merge(g2)
-	require.Empty(t, duplicates, "should have no duplicates since g1 metadata has no content")
+	conflicts, _ := g1.Merge(g2)
+	require.Empty(t, conflicts, "should have no duplicates since g1 metadata has no content")
 	require.NotNil(t, g1.ImportMetadata)
 	require.Equal(t, "NewApp", g1.ImportMetadata.SourceSystem)
 }

--- a/go-glx/types_merge_test.go
+++ b/go-glx/types_merge_test.go
@@ -28,7 +28,7 @@ func TestGLXFile_Merge_EmptyFiles(t *testing.T) {
 	g2 := &GLXFile{}
 
 	conflicts, _ := g1.Merge(g2)
-	require.Empty(t, conflicts, "merging empty files should have no duplicates")
+	require.Empty(t, conflicts, "merging empty files should have no conflicts")
 }
 
 func TestGLXFile_Merge_NilDestMaps(t *testing.T) {
@@ -47,7 +47,7 @@ func TestGLXFile_Merge_NilDestMaps(t *testing.T) {
 	}
 
 	conflicts, _ := g1.Merge(g2)
-	require.Empty(t, conflicts, "should have no duplicates")
+	require.Empty(t, conflicts, "should have no conflicts")
 	require.Len(t, g1.Persons, 1, "persons should be merged into initialized map")
 	require.Len(t, g1.Events, 1, "events should be merged into initialized map")
 	require.Len(t, g1.Places, 1, "places should be merged into initialized map")
@@ -68,7 +68,7 @@ func TestGLXFile_Merge_Persons_NoDuplicates(t *testing.T) {
 	}
 
 	conflicts, _ := g1.Merge(g2)
-	require.Empty(t, conflicts, "should have no duplicates")
+	require.Empty(t, conflicts, "should have no conflicts")
 	require.Len(t, g1.Persons, 2, "should have merged both persons")
 	require.Contains(t, g1.Persons, "person-1")
 	require.Contains(t, g1.Persons, "person-2")
@@ -89,11 +89,11 @@ func TestGLXFile_Merge_Persons_WithDuplicates(t *testing.T) {
 	}
 
 	conflicts, _ := g1.Merge(g2)
-	require.Len(t, conflicts, 1, "should detect one duplicate")
+	require.Len(t, conflicts, 1, "should detect one conflict")
 	require.Contains(t, conflicts[0], "conflict persons ID: person-1")
 
 	// person-2 should still be merged
-	require.Len(t, g1.Persons, 2, "should merge non-duplicate persons")
+	require.Len(t, g1.Persons, 2, "should merge non-conflicting persons")
 	require.Contains(t, g1.Persons, "person-2")
 }
 
@@ -124,7 +124,7 @@ func TestGLXFile_Merge_AllEntityTypes(t *testing.T) {
 	}
 
 	conflicts, _ := g1.Merge(g2)
-	require.Empty(t, conflicts, "should have no duplicates")
+	require.Empty(t, conflicts, "should have no conflicts")
 
 	// Verify all entity types were merged
 	require.Len(t, g1.Persons, 2)
@@ -159,7 +159,7 @@ func TestGLXFile_Merge_Vocabularies_NoDuplicates(t *testing.T) {
 	}
 
 	conflicts, _ := g1.Merge(g2)
-	require.Empty(t, conflicts, "should have no duplicates")
+	require.Empty(t, conflicts, "should have no conflicts")
 	require.Len(t, g1.EventTypes, 2)
 	require.Len(t, g1.ParticipantRoles, 2)
 }
@@ -215,7 +215,7 @@ func TestGLXFile_Merge_AllVocabularyTypes(t *testing.T) {
 	}
 
 	conflicts, _ := g1.Merge(g2)
-	require.Empty(t, conflicts, "should have no duplicates")
+	require.Empty(t, conflicts, "should have no conflicts")
 
 	// Verify all vocabulary types were merged
 	require.Len(t, g1.EventTypes, 2)
@@ -250,7 +250,7 @@ func TestGLXFile_Merge_PropertyVocabularies_NoDuplicates(t *testing.T) {
 	}
 
 	conflicts, _ := g1.Merge(g2)
-	require.Empty(t, conflicts, "should have no duplicates")
+	require.Empty(t, conflicts, "should have no conflicts")
 	require.Len(t, g1.PersonProperties, 2)
 	require.Len(t, g1.EventProperties, 2)
 }
@@ -296,7 +296,7 @@ func TestGLXFile_Merge_AllPropertyVocabularies(t *testing.T) {
 	}
 
 	conflicts, _ := g1.Merge(g2)
-	require.Empty(t, conflicts, "should have no duplicates")
+	require.Empty(t, conflicts, "should have no conflicts")
 
 	// Verify all property vocabulary types were merged
 	require.Len(t, g1.PersonProperties, 2)
@@ -335,7 +335,7 @@ func TestGLXFile_Merge_MultipleDuplicates(t *testing.T) {
 	}
 
 	conflicts, skipped := g1.Merge(g2)
-	require.Len(t, conflicts, 2, "should detect two entity duplicates")
+	require.Len(t, conflicts, 2, "should detect two entity conflicts")
 	require.Equal(t, 1, skipped, "should silently skip one identical vocab entry")
 
 	// Check that entity duplicates are reported
@@ -371,7 +371,7 @@ func TestGLXFile_Merge_NilMaps(t *testing.T) {
 	}
 
 	conflicts, _ := g1.Merge(g2)
-	require.Empty(t, conflicts, "should have no duplicates")
+	require.Empty(t, conflicts, "should have no conflicts")
 
 	// nil dest maps should be initialized and populated with source data
 	require.NotNil(t, g1.Persons)
@@ -397,7 +397,7 @@ func TestGLXFile_Merge_SourceNilMaps(t *testing.T) {
 	}
 
 	conflicts, _ := g1.Merge(g2)
-	require.Empty(t, conflicts, "should have no duplicates")
+	require.Empty(t, conflicts, "should have no conflicts")
 
 	// Destination should remain unchanged
 	require.Len(t, g1.Persons, 1)
@@ -439,7 +439,7 @@ func TestGLXFile_Merge_MixedEntitiesAndVocabularies(t *testing.T) {
 	}
 
 	conflicts, _ := g1.Merge(g2)
-	require.Empty(t, conflicts, "should have no duplicates")
+	require.Empty(t, conflicts, "should have no conflicts")
 
 	// Verify everything merged correctly
 	require.Len(t, g1.Persons, 2)
@@ -498,7 +498,7 @@ func TestGLXFile_Merge_DuplicateReporting(t *testing.T) {
 	}
 
 	conflicts, _ := g1.Merge(g2)
-	require.Len(t, conflicts, 9, "should detect 9 duplicates")
+	require.Len(t, conflicts, 9, "should detect 9 conflicts")
 
 	// Verify messages include the entity type and ID
 	duplicateStr := ""
@@ -532,7 +532,7 @@ func TestGLXFile_Merge_Metadata_AdoptFromOther(t *testing.T) {
 	}
 
 	conflicts, _ := g1.Merge(g2)
-	require.Empty(t, conflicts, "should have no duplicates")
+	require.Empty(t, conflicts, "should have no conflicts")
 	require.NotNil(t, g1.ImportMetadata, "metadata should be adopted from other")
 	require.Equal(t, "MyApp", g1.ImportMetadata.SourceSystem)
 	require.Equal(t, DateString("2026-01-15"), g1.ImportMetadata.ExportDate)
@@ -553,7 +553,7 @@ func TestGLXFile_Merge_Metadata_DuplicateDetected(t *testing.T) {
 	}
 
 	conflicts, _ := g1.Merge(g2)
-	require.Len(t, conflicts, 1, "should detect one metadata duplicate")
+	require.Len(t, conflicts, 1, "should detect one metadata conflict")
 	require.Contains(t, conflicts[0], "conflict metadata")
 
 	// Original metadata is preserved (first one wins)
@@ -570,7 +570,7 @@ func TestGLXFile_Merge_Metadata_EmptyMetadataIgnored(t *testing.T) {
 	}
 
 	conflicts, _ := g1.Merge(g2)
-	require.Empty(t, conflicts, "should have no duplicates")
+	require.Empty(t, conflicts, "should have no conflicts")
 	require.Nil(t, g1.ImportMetadata, "empty metadata should not be adopted")
 }
 
@@ -602,7 +602,7 @@ func TestGLXFile_Merge_Metadata_ExistingEmptyDoesNotConflict(t *testing.T) {
 	}
 
 	conflicts, _ := g1.Merge(g2)
-	require.Empty(t, conflicts, "should have no duplicates since g1 metadata has no content")
+	require.Empty(t, conflicts, "should have no conflicts since g1 metadata has no content")
 	require.NotNil(t, g1.ImportMetadata)
 	require.Equal(t, "NewApp", g1.ImportMetadata.SourceSystem)
 }

--- a/go-glx/types_merge_test.go
+++ b/go-glx/types_merge_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -89,7 +90,7 @@ func TestGLXFile_Merge_Persons_WithDuplicates(t *testing.T) {
 
 	conflicts, _ := g1.Merge(g2)
 	require.Len(t, conflicts, 1, "should detect one duplicate")
-	require.Contains(t, conflicts[0], "duplicate persons ID: person-1")
+	require.Contains(t, conflicts[0], "conflict persons ID: person-1")
 
 	// person-2 should still be merged
 	require.Len(t, g1.Persons, 2, "should merge non-duplicate persons")
@@ -507,15 +508,15 @@ func TestGLXFile_Merge_DuplicateReporting(t *testing.T) {
 	}
 	duplicateStr += duplicateStrSb476.String()
 
-	require.Contains(t, duplicateStr, "duplicate persons ID: person-1")
-	require.Contains(t, duplicateStr, "duplicate events ID: event-1")
-	require.Contains(t, duplicateStr, "duplicate relationships ID: rel-1")
-	require.Contains(t, duplicateStr, "duplicate places ID: place-1")
-	require.Contains(t, duplicateStr, "duplicate sources ID: source-1")
-	require.Contains(t, duplicateStr, "duplicate citations ID: citation-1")
-	require.Contains(t, duplicateStr, "duplicate repositories ID: repo-1")
-	require.Contains(t, duplicateStr, "duplicate assertions ID: assertion-1")
-	require.Contains(t, duplicateStr, "duplicate media ID: media-1")
+	require.Contains(t, duplicateStr, "conflict persons ID: person-1")
+	require.Contains(t, duplicateStr, "conflict events ID: event-1")
+	require.Contains(t, duplicateStr, "conflict relationships ID: rel-1")
+	require.Contains(t, duplicateStr, "conflict places ID: place-1")
+	require.Contains(t, duplicateStr, "conflict sources ID: source-1")
+	require.Contains(t, duplicateStr, "conflict citations ID: citation-1")
+	require.Contains(t, duplicateStr, "conflict repositories ID: repo-1")
+	require.Contains(t, duplicateStr, "conflict assertions ID: assertion-1")
+	require.Contains(t, duplicateStr, "conflict media ID: media-1")
 }
 
 func TestGLXFile_Merge_Metadata_AdoptFromOther(t *testing.T) {
@@ -553,7 +554,7 @@ func TestGLXFile_Merge_Metadata_DuplicateDetected(t *testing.T) {
 
 	conflicts, _ := g1.Merge(g2)
 	require.Len(t, conflicts, 1, "should detect one metadata duplicate")
-	require.Contains(t, conflicts[0], "duplicate metadata")
+	require.Contains(t, conflicts[0], "conflict metadata")
 
 	// Original metadata is preserved (first one wins)
 	require.Equal(t, "AppA", g1.ImportMetadata.SourceSystem)
@@ -660,6 +661,6 @@ func TestGLXFile_Merge_ConflictingVocabsReported(t *testing.T) {
 	conflicts, skipped := g1.Merge(g2)
 	require.Len(t, conflicts, 2, "should report two conflicts")
 	require.Equal(t, 0, skipped, "no identical entries to skip")
-	require.Contains(t, conflicts[0], "conflict")
-	require.Contains(t, conflicts[1], "conflict")
+	assert.Contains(t, conflicts[0], "event_types ID: birth")
+	assert.Contains(t, conflicts[1], "person_properties ID: name")
 }


### PR DESCRIPTION
## What and why

When merging two archives that both embed standard vocabularies, `glx merge` produced ~230 noisy "duplicate" warnings for every standard vocabulary entry, burying the useful information about new entities and real conflicts.

Now, identical vocabulary/property entries (same key + same value via `reflect.DeepEqual`) are silently skipped with a summary count. Only true conflicts (same key, different value) are reported.

Entity duplicates are still always reported regardless of value equality.

**Before:**
```
Duplicates (233 — skipped, destination kept):
  duplicate event_types ID: burial
  duplicate event_types ID: emigration
  ... (230 more lines)
  duplicate persons ID: person-1
```

**After:**
```
Conflicts (1 — skipped, destination kept):
  duplicate persons ID: person-1

230 identical vocabulary/property entries skipped
```

## Related issues

Closes #273

## Testing

- [x] 24 library-level merge tests pass (2 new: identical dedup, conflicting vocab)
- [x] CLI merge runner tests updated for new field names
- [x] Full test suite passes

## Breaking changes

`GLXFile.Merge()` signature changed from `[]string` to `([]string, int)`. This is a library API change but the project is pre-1.0 (beta).