### PR TITLE
chore: add tidy-check Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # GENEALOGIX Makefile
-.PHONY: help build build-cli build-website install-deps lint lint-fix test test-verbose test-race test-coverage bench mod-tidy mod-verify clean fmt check-schemas check-links release-snapshot
+.PHONY: help build build-cli build-website install-deps lint lint-fix test test-verbose test-race test-coverage bench mod-tidy mod-verify tidy-check clean fmt check-schemas check-links release-snapshot
 
 .DEFAULT_GOAL := help
 
@@ -75,6 +75,9 @@ mod-tidy: ## Tidy Go module dependencies
 
 mod-verify: ## Verify Go module integrity
 	go mod verify
+
+tidy-check: ## Verify go.mod and go.sum are tidy
+	go mod tidy -diff
 
 ## Specification
 check-schemas: ## Validate JSON schema files


### PR DESCRIPTION
## Summary

Add a read-only `make tidy-check` target that runs `go mod tidy -diff` to verify go.mod and go.sum are tidy without modifying them, mirroring the `validate-mod` CI job.

Fixes #627

## Test plan

- [ ] Verify `make tidy-check` appears in `make help` output
- [ ] Verify `make tidy-check` exits 0 on a clean repo (go.mod/go.sum are tidy)
- [ ] Verify `make tidy-check` exits 1 and prints a diff when go.mod is untidy