### PR TITLE
chore: consolidate go.mod and remove non-standard comments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,3 @@
-// GENEALOGIX Specification
-// Official specification and tools for the GENEALOGIX family archive format.
-// Provides JSON schemas, validation tools, and examples for genealogical data.
 module github.com/genealogix/glx
 
 go 1.26.0
@@ -8,27 +5,19 @@ go 1.26.0
 toolchain go1.26.1
 
 require (
-	github.com/xeipuuv/gojsonschema v1.2.0
-	// YAML parsing for CLI tool
-	gopkg.in/yaml.v3 v3.0.1
-)
-
-require (
 	github.com/brianvoe/gofakeit/v7 v7.14.1
 	github.com/spf13/cobra v1.10.2
-	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/stretchr/testify v1.11.1
-	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
-	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0
+	golang.org/x/text v0.35.0
+	gopkg.in/yaml.v3 v3.0.1
 )
-
-require golang.org/x/text v0.35.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 )
-
-// CLI tool for GENEALOGIX archives
-// See: ./glx/main.go


### PR DESCRIPTION
## Summary

- Remove 3 free-form comment blocks from go.mod (module description, inline YAML note, trailing CLI reference)
- Consolidate 4 require blocks into the standard 2 (direct + indirect)
- Alphabetically sort all dependencies
- Run `go mod tidy` to normalize

go.mod goes from 35 lines to 24 lines. No functional change — same dependencies, same versions.

Fixes #479

## Test plan

- [ ] Verify go.mod has exactly 2 require blocks (direct + indirect)
- [ ] Verify no free-form comments remain
- [ ] Verify `go mod tidy -diff` shows no changes (CI `validate-mod` check)
- [ ] Verify `make test` passes