### PR TITLE
chore: suppress npm fund messages in CI

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+fund=false


### PR DESCRIPTION
## Summary
- Add root `.npmrc` with `fund=false` to suppress "packages looking for funding" messages in CI logs

Applies to all `npm ci`/`npm install` calls across workflows and Makefile.