### PR TITLE
chore: suppress npm fund in specification/ and website/ subdirectories

### DIFF
--- a/specification/.npmrc
+++ b/specification/.npmrc
@@ -1,0 +1,1 @@
+fund=false

--- a/website/.npmrc
+++ b/website/.npmrc
@@ -1,0 +1,1 @@
+fund=false


### PR DESCRIPTION
## Summary
- Add `.npmrc` with `fund=false` to `specification/` and `website/`
- The root `.npmrc` from #661 only applies to root-level npm commands; subdirectory npm projects need their own config

Fixes the "2 packages are looking for funding" message in the "Install schema validation deps" CI step.