### PR TITLE
fix: Preserve non-archive files in safeWriteMultiFileArchive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Fixed
+
+#### CLI
+- **`glx migrate`, `glx rename`, and `glx merge` no longer delete non-archive files** — The crash-safe write path (`safeWriteMultiFileArchive`, added in #598) swapped a fresh archive directory into place and then unconditionally removed the original via `.bak`, wiping any top-level entry the serializer didn't produce — including `.git/`, `README.md`, `CLAUDE.md`, `.claude/`, and arbitrary user content. Since GLX archives are designed to live inside git repositories, every invocation against a real archive silently destroyed git history and project docs. The swap now preserves every top-level entry that isn't in the managed set (`metadata.glx`, `vocabularies/`, `persons/`, `events/`, `relationships/`, `places/`, `sources/`, `citations/`, `repositories/`, `media/`, `assertions/`). Test coverage added for foreign-file preservation. Fixes #692
+
 ## [0.0.0-beta.10] - 2026-04-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 #### CLI
 - **`glx migrate`, `glx rename`, and `glx merge` no longer delete non-archive files** — The crash-safe write path (`safeWriteMultiFileArchive`, added in #598) swapped a fresh archive directory into place and then unconditionally removed the original via `.bak`, wiping any top-level entry the serializer didn't produce — including `.git/`, `README.md`, `CLAUDE.md`, `.claude/`, and arbitrary user content. Since GLX archives are designed to live inside git repositories, every invocation against a real archive silently destroyed git history and project docs. The swap now preserves every top-level entry that isn't in the managed set (`metadata.glx`, `vocabularies/`, `persons/`, `events/`, `relationships/`, `places/`, `sources/`, `citations/`, `repositories/`, `media/`, `assertions/`). Test coverage added for foreign-file preservation. Fixes #692
 
-## [0.0.0-beta.10] - 2026-04-11
+## [0.0.0-beta.10] - 2026-04-13
 
 ### Added
 
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - **Added `glx migrate` command** — Converts deprecated person properties (`born_on`, `born_at`, `died_on`, `died_at`, `buried_on`, `buried_at`) to birth/death/burial Event entities. Creates new events when none exist, merges date/place into existing events when they do, converts property assertions to event assertions, and removes the deprecated properties (#360, Fixes #645)
 - **Added `--phonetic` flag to `glx query persons --name`** — Soundex phonetic matching finds names that sound alike regardless of spelling (Miller/Myller/Mueller, Smith/Smyth). Supports multi-word queries matching any word against any name word (#262)
 - **Crash-safe writes for `migrate` and `rename` commands** — Multi-file archive writes now use a temp directory + atomic swap, preventing archive corruption on interrupted writes (e.g., power loss, disk full). Closes #597
+- **Added `IOStreams` type for testable CLI output** — New `glx/iostreams.go` introduces `IOStreams{Out, ErrOut io.Writer}` following kubectl's minimal pattern. `validatePaths()` migrated to accept `*IOStreams` instead of writing directly to `os.Stdout`/`os.Stderr`; all 18 validation tests use `TestIOStreams()` with buffer capture instead of `os.Pipe()` hacks. Foundation for incremental migration of remaining runners (#682, Fixes #678)
 
 #### Date Handling
 - **Non-Gregorian calendar support** — GEDCOM calendar escape sequences (`@#DJULIAN@`, `@#DHEBREW@`, `@#DFRENCH R@`) are now preserved as calendar prefixes on DateString values (e.g., `JULIAN 1731-03-15`). Previously, calendar designations were silently discarded. Gregorian remains the default (no prefix). Includes full roundtrip support on GEDCOM export (#564)
@@ -46,6 +47,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Fixed
 
+#### CLI
+- **`glx vitals` limited to core vital records only** — Removed non-vital events (census, marriage, residence, etc.) from `glx vitals` output. Vitals now shows exactly Name, Sex, Birth, Christening, Death, Burial; other life events remain available via `glx summary` and `glx timeline` (#685, Fixes #644)
+- **Witness events excluded from vital records display** — `glx vitals` and `glx summary` vital sections now show vital events (birth, christening, death, burial) only where the person is a principal/subject participant. Witnessing a christening (or other vital event) no longer appears as the person's own vital. Non-vital "Life Events" in `glx summary` continue to show all participant roles (#686, Fixes #647)
+
 #### GEDCOM Import
 - **Unrecognized SEX values preserved** — Non-standard or extension GEDCOM SEX values (e.g., custom values, or values such as `N` whose meaning varies between GEDCOM 5.5.5 `Not Recorded` and 7.0 `Nonbinary`) are now lowercased and preserved as-is instead of being silently mapped to `unknown`. Validation will warn about out-of-vocabulary values (#588)
 - **Correct year extraction from Hebrew and French Republican dates** — `ExtractFirstYear` now uses calendar-aware extraction, finding the last digit sequence for HEBREW and FRENCH_R dates where the year appears last. Previously, `HEBREW 15 TSH 5765` would extract `15` (the day) instead of `5765`. Also handles range dates (`BET...AND`, `FROM...TO`) correctly (#590)
@@ -55,6 +60,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 #### Developer Experience
 - **devcontainer: remove abandoned ajv-cli and install actual npm deps** — Replaced the unused global `ajv-cli` install with parallel `postCreateCommand` that runs `go mod download`, pins `golangci-lint v2.11.4`, and installs `specification/` and `website/` npm dependencies. Removed unused Docker extension, added YAML and markdownlint extensions, added `forwardPorts` for VitePress dev server (#326, #327)
+- **`go.mod` / `go.sum` pinned to LF line endings** — Added `eol=lf` for `go.mod` and `go.sum` in `.gitattributes`. Go tools always write LF (see golang/go#31870); without this rule, Windows users got CRLF on checkout, which caused `go mod tidy -diff` false positives in CI (#684, Fixes #638)
+- **`/check-code-drift` slash command covers all type categories** — Expanded the drift-detection checklist to cover Metadata, Submitter, EntityRef, NoteList, all 9 vocabulary structs, and FieldDefinition. Added type-mapping entries for `NoteList` (`oneOf`), `DateString` (alias), `*Submitter` (pointer). New "Vocabulary Struct Types" section enumerates the 9 vocab types and their schemas. Documentation only (#689, Fixes #674)
 
 #### CI
 - **auto-resolve-conflicts: deduplicate changelog section headers after conflict resolution** — The sed-based "keep both sides" merge produced duplicate `###`/`####` headers when both sides added entries to the same section. Added an awk deduplication pass that merges entries under a single header (#331)

--- a/glx/archive_io.go
+++ b/glx/archive_io.go
@@ -23,9 +23,30 @@ import (
 	glxlib "github.com/genealogix/glx/go-glx"
 )
 
+// archiveManagedTopLevel is the set of top-level paths written by the multi-file
+// serializer. Anything in an archive directory that isn't in this set is foreign
+// (user docs, .git, dotfiles, etc.) and must be preserved across a safe-write swap.
+// See genealogix/glx#692.
+var archiveManagedTopLevel = map[string]bool{
+	"metadata.glx":  true,
+	"vocabularies":  true,
+	"persons":       true,
+	"events":        true,
+	"relationships": true,
+	"places":        true,
+	"sources":       true,
+	"citations":     true,
+	"repositories":  true,
+	"media":         true,
+	"assertions":    true,
+}
+
 // safeWriteMultiFileArchive writes a multi-file archive to a temporary directory
 // first, then swaps it into place. This prevents archive destruction if the write
 // fails partway through (e.g., power loss, disk full, signal).
+//
+// Non-archive top-level entries in destPath (e.g., .git, README.md, CLAUDE.md,
+// dotfiles) are preserved across the swap; see archiveManagedTopLevel.
 func safeWriteMultiFileArchive(destPath string, archive *glxlib.GLXFile) error {
 	// Resolve to absolute path so rename and cwd containment checks work
 	// reliably for relative paths like ".". mergeArchives does the same.
@@ -74,8 +95,8 @@ func safeWriteMultiFileArchive(destPath string, archive *glxlib.GLXFile) error {
 
 	// Create backup of the original
 	backupDir := destPath + ".bak"
-	if err := os.RemoveAll(backupDir); err != nil {
-		return fmt.Errorf("removing stale backup %s: %w", backupDir, err)
+	if err := removeStaleBackup(backupDir); err != nil {
+		return err
 	}
 	if err := os.Rename(destPath, backupDir); err != nil {
 		return fmt.Errorf("backing up original: %w", err)
@@ -88,9 +109,74 @@ func safeWriteMultiFileArchive(destPath string, archive *glxlib.GLXFile) error {
 		return fmt.Errorf("moving archive into place: %w", err)
 	}
 
-	// Clean up backup
+	// Preserve foreign (non-managed) top-level entries from the backup back into
+	// the newly-written archive. Without this step the swap silently destroys
+	// .git, README.md, and any other user content that sits alongside the
+	// managed entity directories — see genealogix/glx#692.
+	if err := restoreForeignEntries(backupDir, destPath); err != nil {
+		// Leave backupDir in place so the user can recover. Do not mark success.
+		return fmt.Errorf("preserving non-archive files: %w", err)
+	}
+
+	// Clean up backup (now contains only managed entries that have been
+	// superseded by the fresh write).
 	_ = os.RemoveAll(backupDir)
 	success = true
+	return nil
+}
+
+// removeStaleBackup deletes a leftover .bak directory, but only after verifying
+// it contains no foreign (non-managed) entries. If it does, a previous invocation
+// failed mid-restore and those entries are the user's unrecovered data — refuse
+// to proceed rather than silently destroy them.
+func removeStaleBackup(backupDir string) error {
+	entries, err := os.ReadDir(backupDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("inspecting stale backup %s: %w", backupDir, err)
+	}
+	for _, entry := range entries {
+		if !archiveManagedTopLevel[entry.Name()] {
+			return fmt.Errorf(
+				"stale backup %s contains non-archive file %q from a previous failed run; "+
+					"move or inspect it before retrying",
+				backupDir, entry.Name(),
+			)
+		}
+	}
+	if err := os.RemoveAll(backupDir); err != nil {
+		return fmt.Errorf("removing stale backup %s: %w", backupDir, err)
+	}
+	return nil
+}
+
+// restoreForeignEntries moves every top-level entry from backupDir into destPath
+// unless the entry name is in archiveManagedTopLevel. The source and destination
+// are on the same filesystem (backupDir and destPath share a parent), so each
+// rename is atomic.
+//
+// Preservation runs after the swap rather than before, so at every intermediate
+// state the user's data exists on disk under a predictable name: before the
+// rename it lives in backupDir (still named destPath.bak); after it lives in
+// destPath. If any rename fails the backup is retained so the user can recover.
+func restoreForeignEntries(backupDir, destPath string) error {
+	entries, err := os.ReadDir(backupDir)
+	if err != nil {
+		return fmt.Errorf("reading backup directory: %w", err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if archiveManagedTopLevel[name] {
+			continue
+		}
+		src := filepath.Join(backupDir, name)
+		dst := filepath.Join(destPath, name)
+		if err := os.Rename(src, dst); err != nil {
+			return fmt.Errorf("restoring %s: %w", name, err)
+		}
+	}
 	return nil
 }
 

--- a/glx/archive_io.go
+++ b/glx/archive_io.go
@@ -106,6 +106,7 @@ func safeWriteMultiFileArchive(destPath string, archive *glxlib.GLXFile) error {
 	if err := os.Rename(tmpDir, destPath); err != nil {
 		// Restore backup on failure
 		_ = os.Rename(backupDir, destPath) // best-effort restore
+
 		return fmt.Errorf("moving archive into place: %w", err)
 	}
 
@@ -122,6 +123,7 @@ func safeWriteMultiFileArchive(destPath string, archive *glxlib.GLXFile) error {
 	// superseded by the fresh write).
 	_ = os.RemoveAll(backupDir)
 	success = true
+
 	return nil
 }
 
@@ -135,20 +137,18 @@ func removeStaleBackup(backupDir string) error {
 		if os.IsNotExist(err) {
 			return nil
 		}
+
 		return fmt.Errorf("inspecting stale backup %s: %w", backupDir, err)
 	}
 	for _, entry := range entries {
 		if !archiveManagedTopLevel[entry.Name()] {
-			return fmt.Errorf(
-				"stale backup %s contains non-archive file %q from a previous failed run; "+
-					"move or inspect it before retrying",
-				backupDir, entry.Name(),
-			)
+			return fmt.Errorf("%w: %s contains %q", ErrStaleBackupForeignFile, backupDir, entry.Name())
 		}
 	}
 	if err := os.RemoveAll(backupDir); err != nil {
 		return fmt.Errorf("removing stale backup %s: %w", backupDir, err)
 	}
+
 	return nil
 }
 
@@ -177,6 +177,7 @@ func restoreForeignEntries(backupDir, destPath string) error {
 			return fmt.Errorf("restoring %s: %w", name, err)
 		}
 	}
+
 	return nil
 }
 

--- a/glx/archive_io_test.go
+++ b/glx/archive_io_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -953,6 +954,115 @@ func TestSafeWriteMultiFileArchive(t *testing.T) {
 		}
 		if len(loaded.Persons) != 2 {
 			t.Errorf("expected 2 persons, got %d", len(loaded.Persons))
+		}
+	})
+
+	t.Run("preserves non-archive files and directories", func(t *testing.T) {
+		// Archives typically live inside a git repo alongside README.md, CLAUDE.md,
+		// dotfiles, and top-level metadata. The safe-write swap must preserve
+		// everything it doesn't manage. See #692.
+		tmpDir := t.TempDir()
+		archiveDir := filepath.Join(tmpDir, "archive")
+		if err := os.MkdirAll(archiveDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		// Seed with initial GLX content
+		if err := writeMultiFileArchive(archiveDir, makeArchive(), false); err != nil {
+			t.Fatal(err)
+		}
+
+		// Seed with foreign files the archive must preserve
+		foreignFiles := map[string][]byte{
+			"README.md":                    []byte("# Archive\n\nUser notes.\n"),
+			"CLAUDE.md":                    []byte("# Claude guide\n"),
+			".gitignore":                   []byte("*.log\n"),
+			".git/HEAD":                    []byte("ref: refs/heads/main\n"),
+			".git/config":                  []byte("[core]\n\trepositoryformatversion = 0\n"),
+			".git/refs/heads/main":         []byte("abc123\n"),
+			".claude/settings.local.json":  []byte(`{"env":{}}`),
+			"notes/research.md":            []byte("Research notes.\n"),
+		}
+		for relPath, content := range foreignFiles {
+			absPath := filepath.Join(archiveDir, relPath)
+			if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(absPath, content, 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// Run the safe write
+		if err := safeWriteMultiFileArchive(archiveDir, makeArchive()); err != nil {
+			t.Fatalf("safeWriteMultiFileArchive() error = %v", err)
+		}
+
+		// Every foreign file must survive byte-identical
+		for relPath, want := range foreignFiles {
+			absPath := filepath.Join(archiveDir, relPath)
+			got, err := os.ReadFile(absPath)
+			if err != nil {
+				t.Errorf("foreign file %s lost: %v", relPath, err)
+				continue
+			}
+			if !bytes.Equal(got, want) {
+				t.Errorf("foreign file %s contents differ\nwant: %q\ngot:  %q", relPath, want, got)
+			}
+		}
+
+		// Archive content must also be in place
+		loaded, _, err := LoadArchiveWithOptions(archiveDir, false)
+		if err != nil {
+			t.Fatalf("LoadArchiveWithOptions() error = %v", err)
+		}
+		if len(loaded.Persons) != 2 {
+			t.Errorf("expected 2 persons, got %d", len(loaded.Persons))
+		}
+
+		// No backup directory should remain
+		if _, err := os.Stat(archiveDir + ".bak"); !os.IsNotExist(err) {
+			t.Error("backup directory was not cleaned up")
+		}
+	})
+
+	t.Run("refuses to wipe stale backup holding unrecovered foreign files", func(t *testing.T) {
+		// Simulates a previous invocation that crashed mid-restore, leaving a
+		// .bak directory with the user's foreign files in it. The next run must
+		// refuse rather than silently wipe that recovery data. See #692.
+		tmpDir := t.TempDir()
+		archiveDir := filepath.Join(tmpDir, "archive")
+		if err := os.MkdirAll(archiveDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := writeMultiFileArchive(archiveDir, makeArchive(), false); err != nil {
+			t.Fatal(err)
+		}
+
+		// Plant a stale backup containing foreign content
+		staleBackup := archiveDir + ".bak"
+		if err := os.MkdirAll(staleBackup, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(staleBackup, "unrecovered-notes.md"), []byte("user data"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		err := safeWriteMultiFileArchive(archiveDir, makeArchive())
+		if err == nil {
+			t.Fatal("expected error when stale backup contains foreign files")
+		}
+		if !strings.Contains(err.Error(), "unrecovered-notes.md") {
+			t.Errorf("error should mention the foreign file; got: %v", err)
+		}
+
+		// Foreign data must still be on disk
+		got, readErr := os.ReadFile(filepath.Join(staleBackup, "unrecovered-notes.md"))
+		if readErr != nil {
+			t.Fatalf("stale backup contents destroyed: %v", readErr)
+		}
+		if string(got) != "user data" {
+			t.Errorf("stale backup corrupted; got %q", got)
 		}
 	})
 

--- a/glx/archive_io_test.go
+++ b/glx/archive_io_test.go
@@ -974,14 +974,14 @@ func TestSafeWriteMultiFileArchive(t *testing.T) {
 
 		// Seed with foreign files the archive must preserve
 		foreignFiles := map[string][]byte{
-			"README.md":                    []byte("# Archive\n\nUser notes.\n"),
-			"CLAUDE.md":                    []byte("# Claude guide\n"),
-			".gitignore":                   []byte("*.log\n"),
-			".git/HEAD":                    []byte("ref: refs/heads/main\n"),
-			".git/config":                  []byte("[core]\n\trepositoryformatversion = 0\n"),
-			".git/refs/heads/main":         []byte("abc123\n"),
-			".claude/settings.local.json":  []byte(`{"env":{}}`),
-			"notes/research.md":            []byte("Research notes.\n"),
+			"README.md":                   []byte("# Archive\n\nUser notes.\n"),
+			"CLAUDE.md":                   []byte("# Claude guide\n"),
+			".gitignore":                  []byte("*.log\n"),
+			".git/HEAD":                   []byte("ref: refs/heads/main\n"),
+			".git/config":                 []byte("[core]\n\trepositoryformatversion = 0\n"),
+			".git/refs/heads/main":        []byte("abc123\n"),
+			".claude/settings.local.json": []byte(`{"env":{}}`),
+			"notes/research.md":           []byte("Research notes.\n"),
 		}
 		for relPath, content := range foreignFiles {
 			absPath := filepath.Join(archiveDir, relPath)
@@ -1004,6 +1004,7 @@ func TestSafeWriteMultiFileArchive(t *testing.T) {
 			got, err := os.ReadFile(absPath)
 			if err != nil {
 				t.Errorf("foreign file %s lost: %v", relPath, err)
+
 				continue
 			}
 			if !bytes.Equal(got, want) {

--- a/glx/errors.go
+++ b/glx/errors.go
@@ -43,4 +43,5 @@ var (
 	ErrMultipleFilesFailed        = errors.New("multiple files failed validation")
 	ErrInvalidExportFormat        = errors.New("invalid GEDCOM version format")
 	ErrInputNotFound              = errors.New("input path not found")
+	ErrStaleBackupForeignFile     = errors.New("stale backup contains non-archive file from a previous failed run; move or inspect it before retrying")
 )


### PR DESCRIPTION
## What and why

The crash-safe multi-file write path added in #598 swapped a fresh archive directory into place via temp-dir + `os.Rename`, then unconditionally removed the original with `os.RemoveAll(backupDir)`. That backup contained every top-level entry the serializer didn't produce — `.git/`, `README.md`, `CLAUDE.md`, `.claude/`, `.gitignore`, and any arbitrary user content — so each `glx migrate`, `glx rename`, and `glx merge` silently destroyed project history and docs on real archives.

After the swap, this patch moves every top-level entry from the `.bak` directory back into `destPath` unless the entry name is in a managed set (`metadata.glx` + the nine entity directories the serializer writes). Both dirs share a filesystem, so the renames are atomic.

Also guards the stale-`.bak` wipe at the top of the function: if a previous run died mid-restore and left foreign data in `.bak`, the next run now refuses rather than silently deleting it.

## Related issues

Fixes #692

## Testing

- Added `TestSafeWriteMultiFileArchive/preserves_non-archive_files_and_directories`: seeds `destPath` with `.git/HEAD`, `.git/config`, `.git/refs/heads/main`, `README.md`, `CLAUDE.md`, `.gitignore`, `.claude/settings.local.json`, and `notes/research.md`, then asserts every foreign file survives byte-identical after `safeWriteMultiFileArchive`.
- Added `TestSafeWriteMultiFileArchive/refuses_to_wipe_stale_backup_holding_unrecovered_foreign_files`: plants a stale `.bak` with user data, asserts the next run errors instead of destroying it.
- Live smoke against a fresh `glx-archive-westeros` clone: `.git` (HEAD unchanged), `README.md`, `CLAUDE.md`, `.gitignore`, and `.claude/` all byte-identical after `glx migrate .`; archive entity data also migrated correctly.
- `make test` green. `make lint` failures are pre-existing and not in the files touched.

## Breaking changes

None — this restores the expected behavior. Archives previously written by beta.10's `migrate`/`rename`/`merge` that lost their `.git` or docs need to be restored from the user's remote or backups; this PR prevents the data loss going forward.