### PR TITLE
fix: route copyMediaFiles output through IOStreams

### DIFF
--- a/glx/errors.go
+++ b/glx/errors.go
@@ -23,6 +23,7 @@ var (
 	ErrMediaFileNotFound          = errors.New("file not found")
 	ErrEmptyBlobData              = errors.New("empty BLOB data")
 	ErrInvalidBlobLength          = errors.New("invalid BLOB data length")
+	ErrInvalidBlobChar            = errors.New("invalid BLOB character (must be in range '.' to 'm')")
 	ErrValidationWithErrors       = errors.New("validation failed with errors")
 	ErrInvalidFormat              = errors.New("invalid format (must be 'single' or 'multi')")
 	ErrGEDCOMFileNotFound         = errors.New("GEDCOM file not found")

--- a/glx/import_runner.go
+++ b/glx/import_runner.go
@@ -80,7 +80,7 @@ func importToSingleFile(glx *glxlib.GLXFile, outputPath string, validate, verbos
 
 	// Copy media files into sibling media/files/ directory
 	archiveDir := filepath.Dir(outputPath)
-	if err := copyMediaFiles(archiveDir, mediaFiles, gedcomDir, verbose); err != nil {
+	if err := copyMediaFiles(SystemIOStreams(), archiveDir, mediaFiles, gedcomDir, verbose); err != nil {
 		return fmt.Errorf("failed to copy media files: %w", err)
 	}
 
@@ -102,7 +102,7 @@ func importToMultiFile(glx *glxlib.GLXFile, outputPath string, validate, verbose
 	}
 
 	// Copy media files into the archive's media/files/ directory
-	if err := copyMediaFiles(outputPath, mediaFiles, gedcomDir, verbose); err != nil {
+	if err := copyMediaFiles(SystemIOStreams(), outputPath, mediaFiles, gedcomDir, verbose); err != nil {
 		return fmt.Errorf("failed to copy media files: %w", err)
 	}
 

--- a/glx/media_copy.go
+++ b/glx/media_copy.go
@@ -216,6 +216,9 @@ func decodeGEDCOMBlob(blobText string) ([]byte, error) {
 
 	// Handle trailing characters (2 chars → 1 byte, 3 chars → 2 bytes)
 	trailing := len(cleaned) - fullGroups
+	if trailing == 1 {
+		return nil, fmt.Errorf("%w: %d (trailing single character cannot encode a full byte)", ErrInvalidBlobLength, len(cleaned))
+	}
 	if trailing >= 2 { //nolint:mnd // trailing group sizes
 		for j := range trailing {
 			char := cleaned[fullGroups+j]

--- a/glx/media_copy.go
+++ b/glx/media_copy.go
@@ -29,7 +29,7 @@ import (
 // gedcomDir is the source directory for resolving relative FILE paths.
 // archiveDir is the root of the output archive.
 // Missing source files produce warnings on stderr, not fatal errors.
-func copyMediaFiles(archiveDir string, mediaFiles []glxlib.MediaFileSource, gedcomDir string, verbose bool) error {
+func copyMediaFiles(streams *IOStreams, archiveDir string, mediaFiles []glxlib.MediaFileSource, gedcomDir string, verbose bool) error {
 	if len(mediaFiles) == 0 {
 		return nil
 	}
@@ -47,7 +47,7 @@ func copyMediaFiles(archiveDir string, mediaFiles []glxlib.MediaFileSource, gedc
 		switch mf.SourceType {
 		case glxlib.MediaSourceFile:
 			if err := copyMediaFile(gedcomDir, mf.RelativePath, destPath); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: could not copy media file %s: %v\n", mf.RelativePath, err)
+				streams.Errorf("Warning: could not copy media file %s: %v\n", mf.RelativePath, err)
 				warnCount++
 
 				continue
@@ -57,13 +57,13 @@ func copyMediaFiles(archiveDir string, mediaFiles []glxlib.MediaFileSource, gedc
 		case glxlib.MediaSourceBlob:
 			decoded, err := decodeGEDCOMBlob(mf.BlobData)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: could not decode BLOB for %s: %v\n", mf.MediaID, err)
+				streams.Errorf("Warning: could not decode BLOB for %s: %v\n", mf.MediaID, err)
 				warnCount++
 
 				continue
 			}
 			if err := os.WriteFile(destPath, decoded, filePermissions); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: could not write BLOB file %s: %v\n", destPath, err)
+				streams.Errorf("Warning: could not write BLOB file %s: %v\n", destPath, err)
 				warnCount++
 
 				continue
@@ -73,11 +73,11 @@ func copyMediaFiles(archiveDir string, mediaFiles []glxlib.MediaFileSource, gedc
 	}
 
 	if verbose || copyCount > 0 || blobCount > 0 {
-		fmt.Printf("  Media files: %d copied, %d blobs written", copyCount, blobCount)
+		streams.Printf("  Media files: %d copied, %d blobs written", copyCount, blobCount)
 		if warnCount > 0 {
-			fmt.Printf(", %d warnings", warnCount)
+			streams.Printf(", %d warnings", warnCount)
 		}
-		fmt.Println()
+		streams.Println("")
 	}
 
 	return nil
@@ -187,12 +187,14 @@ func decodeGEDCOMBlob(blobText string) ([]byte, error) {
 		return nil, ErrEmptyBlobData
 	}
 
-	if len(cleaned)%4 != 0 {
-		return nil, fmt.Errorf("%w: %d (must be multiple of 4)", ErrInvalidBlobLength, len(cleaned))
+	if len(cleaned) == 1 {
+		return nil, fmt.Errorf("%w: 1 (minimum 2 characters required)", ErrInvalidBlobLength)
 	}
 
 	result := make([]byte, 0, len(cleaned)*3/4)
-	for i := 0; i < len(cleaned); i += 4 {
+	fullGroups := (len(cleaned) / 4) * 4 //nolint:mnd // 4 chars per group
+
+	for i := 0; i < fullGroups; i += 4 {
 		// Validate each character is in valid GEDCOM BLOB range (0x2E '.' to 0x6D 'm')
 		// This gives 6-bit values (0-63) after subtracting 0x2E
 		for j := 0; j < 4; j++ {
@@ -210,6 +212,26 @@ func decodeGEDCOMBlob(blobText string) ([]byte, error) {
 		result = append(result, (b1<<2)|(b2>>4)) //nolint:mnd // well-known base64 bit shifts
 		result = append(result, (b2<<4)|(b3>>2)) //nolint:mnd // well-known base64 bit shifts
 		result = append(result, (b3<<6)|b4)      //nolint:mnd // well-known base64 bit shifts
+	}
+
+	// Handle trailing characters (2 chars → 1 byte, 3 chars → 2 bytes)
+	trailing := len(cleaned) - fullGroups
+	if trailing >= 2 { //nolint:mnd // trailing group sizes
+		for j := range trailing {
+			char := cleaned[fullGroups+j]
+			if char < '.' || char > 'm' {
+				return nil, fmt.Errorf("%w at position %d: %q", ErrInvalidBlobChar, fullGroups+j, char)
+			}
+		}
+
+		b1 := cleaned[fullGroups] - '.'
+		b2 := cleaned[fullGroups+1] - '.'
+		result = append(result, (b1<<2)|(b2>>4)) //nolint:mnd // well-known base64 bit shifts
+
+		if trailing == 3 { //nolint:mnd // 3-char trailing group
+			b3 := cleaned[fullGroups+2] - '.'
+			result = append(result, (b2<<4)|(b3>>2)) //nolint:mnd // well-known base64 bit shifts
+		}
 	}
 
 	return result, nil

--- a/glx/media_copy_test.go
+++ b/glx/media_copy_test.go
@@ -57,10 +57,37 @@ func TestDecodeGEDCOMBlob(t *testing.T) {
 		t.Error("Expected error for empty blob")
 	}
 
-	// Invalid length (not multiple of 4)
-	_, err = decodeGEDCOMBlob("...")
+	// Trailing 3 chars (valid — produces 2 bytes)
+	decoded3, err := decodeGEDCOMBlob("...")
+	if err != nil {
+		t.Fatalf("Decode of 3 chars failed: %v", err)
+	}
+	if len(decoded3) != 2 {
+		t.Errorf("Expected 2 bytes from 3 chars, got %d", len(decoded3))
+	}
+
+	// Trailing 2 chars (valid — produces 1 byte)
+	decoded4, err := decodeGEDCOMBlob("..")
+	if err != nil {
+		t.Fatalf("Decode of 2 chars failed: %v", err)
+	}
+	if len(decoded4) != 1 {
+		t.Errorf("Expected 1 byte from 2 chars, got %d", len(decoded4))
+	}
+
+	// Mixed: 4 + 2 trailing chars (produces 3 + 1 = 4 bytes)
+	decoded5, err := decodeGEDCOMBlob("......")
+	if err != nil {
+		t.Fatalf("Decode of 6 chars failed: %v", err)
+	}
+	if len(decoded5) != 4 {
+		t.Errorf("Expected 4 bytes from 6 chars, got %d", len(decoded5))
+	}
+
+	// Single char is invalid (not enough bits for a full byte)
+	_, err = decodeGEDCOMBlob(".")
 	if err == nil {
-		t.Error("Expected error for invalid length")
+		t.Error("Expected error for single character")
 	}
 }
 
@@ -87,7 +114,7 @@ func TestCopyMediaFiles_FileCopy(t *testing.T) {
 		},
 	}
 
-	err := copyMediaFiles(destDir, mediaFiles, srcDir, false)
+	err := copyMediaFiles(SystemIOStreams(), destDir, mediaFiles, srcDir, false)
 	if err != nil {
 		t.Fatalf("copyMediaFiles failed: %v", err)
 	}
@@ -115,7 +142,7 @@ func TestCopyMediaFiles_BlobWrite(t *testing.T) {
 		},
 	}
 
-	err := copyMediaFiles(destDir, mediaFiles, "", false)
+	err := copyMediaFiles(SystemIOStreams(), destDir, mediaFiles, "", false)
 	if err != nil {
 		t.Fatalf("copyMediaFiles failed: %v", err)
 	}
@@ -143,8 +170,9 @@ func TestCopyMediaFiles_MissingSourceWarns(t *testing.T) {
 		},
 	}
 
-	// Should not return error (warnings on stderr instead)
-	err := copyMediaFiles(destDir, mediaFiles, srcDir, false)
+	streams, _, errOut := TestIOStreams()
+
+	err := copyMediaFiles(streams, destDir, mediaFiles, srcDir, false)
 	if err != nil {
 		t.Fatalf("copyMediaFiles should not fail for missing files: %v", err)
 	}
@@ -153,6 +181,11 @@ func TestCopyMediaFiles_MissingSourceWarns(t *testing.T) {
 	_, err = os.Stat(filepath.Join(destDir, "media", "files", "nonexistent.jpg"))
 	if !os.IsNotExist(err) {
 		t.Error("Expected file to not exist")
+	}
+
+	// Verify warning was captured
+	if !strings.Contains(errOut.String(), "Warning: could not copy media file nonexistent.jpg") {
+		t.Errorf("expected warning about missing file, got: %q", errOut.String())
 	}
 }
 
@@ -235,7 +268,7 @@ func TestCopyMediaFiles_EmptyList(t *testing.T) {
 	destDir := t.TempDir()
 
 	// Empty list should be a no-op (no media/files directory created)
-	err := copyMediaFiles(destDir, nil, "", false)
+	err := copyMediaFiles(SystemIOStreams(), destDir, nil, "", false)
 	if err != nil {
 		t.Fatalf("copyMediaFiles should succeed for empty list: %v", err)
 	}
@@ -293,7 +326,8 @@ func TestE2E_TortureTest_MediaFileCopy(t *testing.T) {
 
 	// Step 3: Copy media files (CLI layer)
 	destDir := t.TempDir()
-	err = copyMediaFiles(destDir, result.MediaFiles, gedcomDir, false)
+	streams, _, errOut := TestIOStreams()
+	err = copyMediaFiles(streams, destDir, result.MediaFiles, gedcomDir, false)
 	if err != nil {
 		t.Fatalf("copyMediaFiles failed: %v", err)
 	}
@@ -378,14 +412,18 @@ func TestE2E_TortureTest_MediaFileCopy(t *testing.T) {
 		t.Logf("  Blob source tracked: %s (%d chars of blob data)",
 			blobSources[0].TargetFilename, len(blobSources[0].BlobData))
 	}
-	// Check if any blob files were actually written (may be 0 due to malformed data)
+	// Check blob file count. The torture test blob has invalid characters
+	// (outside the '.' to 'm' range), so decoding fails with a warning.
 	var blobFileCount int
 	for _, e := range entries {
 		if strings.HasPrefix(e.Name(), "blob-") {
 			blobFileCount++
 		}
 	}
-	t.Logf("  Blob files written: %d (0 expected — torture test blob is malformed)", blobFileCount)
+	if blobFileCount != 0 {
+		t.Errorf("Expected 0 blob files (torture test blob has invalid chars), got %d", blobFileCount)
+	}
+	t.Logf("  Blob files written: %d (0 expected — torture test blob has invalid characters)", blobFileCount)
 
 	// Step 8: Verify missing files did NOT get created
 	// These files are referenced in the GEDCOM but don't exist on disk
@@ -417,4 +455,23 @@ func TestE2E_TortureTest_MediaFileCopy(t *testing.T) {
 
 	// Step 10: Log total file count in media/files/
 	t.Logf("  Total files in media/files/: %d", len(entries))
+
+	// Step 11: Verify warnings were captured and expected
+	warnings := errOut.String()
+	warnCount := strings.Count(warnings, "Warning:")
+	t.Logf("  Warnings captured: %d", warnCount)
+
+	// These files are referenced in the GEDCOM but don't exist on disk
+	expectedMissing := []string{"Document.RTF", "enthist.aif", "suntun.mov", "top.mpg", "ImgFile.BMP", "force.wav"}
+	for _, name := range expectedMissing {
+		if !strings.Contains(warnings, name) {
+			t.Errorf("Expected warning about missing file %q", name)
+		}
+	}
+
+	// BLOB decode warning IS expected — the torture test blob has invalid characters
+	// (chars outside the '.' to 'm' range required by GEDCOM BLOB encoding)
+	if !strings.Contains(warnings, "could not decode BLOB") {
+		t.Error("Expected BLOB decode warning for malformed torture test blob data")
+	}
 }

--- a/glx/media_copy_test.go
+++ b/glx/media_copy_test.go
@@ -89,6 +89,12 @@ func TestDecodeGEDCOMBlob(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for single character")
 	}
+
+	// 5 chars (4 + 1 trailing) is invalid — trailing single char can't encode a byte
+	_, err = decodeGEDCOMBlob(".....")
+	if err == nil {
+		t.Error("Expected error for 5 chars (trailing single character)")
+	}
 }
 
 func TestCopyMediaFiles_FileCopy(t *testing.T) {
@@ -460,6 +466,10 @@ func TestE2E_TortureTest_MediaFileCopy(t *testing.T) {
 	warnings := errOut.String()
 	warnCount := strings.Count(warnings, "Warning:")
 	t.Logf("  Warnings captured: %d", warnCount)
+	// 8 missing-file warnings (ImgFile.BMP referenced 3 times) + 1 blob decode = 9
+	if warnCount != 9 {
+		t.Errorf("Expected 9 warnings, got %d:\n%s", warnCount, warnings)
+	}
 
 	// These files are referenced in the GEDCOM but don't exist on disk
 	expectedMissing := []string{"Document.RTF", "enthist.aif", "suntun.mov", "top.mpg", "ImgFile.BMP", "force.wav"}


### PR DESCRIPTION
## Summary

- Adds `*IOStreams` parameter to `copyMediaFiles` so warnings and status output are testable instead of writing directly to `os.Stderr`/`os.Stdout`
- Handles trailing BLOB characters in decoder (2 chars → 1 byte, 3 chars → 2 bytes) instead of rejecting non-multiple-of-4 lengths
- Updates E2E torture test to capture and assert on all 9 expected warnings (6 missing-file + 1 blob invalid chars + 2 duplicate missing-file refs)
- Adds `ErrInvalidBlobChar` sentinel error for lint compliance

## Test plan

- [x] `TestDecodeGEDCOMBlob` — new cases for trailing 2-char, 3-char, and 1-char (error) inputs
- [x] `TestCopyMediaFiles_MissingSourceWarns` — now captures stderr and asserts warning content
- [x] `TestE2E_TortureTest_MediaFileCopy` — captures all warnings, asserts on missing-file names and blob decode warning
- [x] All existing tests pass (blob write, file copy, empty list, path traversal)
- [x] No new lint issues (`golangci-lint run --new-from-rev=HEAD`)