### PR TITLE
fix: retry os.Rename on Windows for transient AV/indexer locks

### DIFF
--- a/glx/archive_io.go
+++ b/glx/archive_io.go
@@ -98,14 +98,14 @@ func safeWriteMultiFileArchive(destPath string, archive *glxlib.GLXFile) error {
 	if err := removeStaleBackup(backupDir); err != nil {
 		return err
 	}
-	if err := os.Rename(destPath, backupDir); err != nil {
+	if err := robustRename(destPath, backupDir); err != nil {
 		return fmt.Errorf("backing up original: %w", err)
 	}
 
 	// Move temp into place
-	if err := os.Rename(tmpDir, destPath); err != nil {
+	if err := robustRename(tmpDir, destPath); err != nil {
 		// Restore backup on failure
-		_ = os.Rename(backupDir, destPath) // best-effort restore
+		_ = robustRename(backupDir, destPath) // best-effort restore
 
 		return fmt.Errorf("moving archive into place: %w", err)
 	}
@@ -173,7 +173,7 @@ func restoreForeignEntries(backupDir, destPath string) error {
 		}
 		src := filepath.Join(backupDir, name)
 		dst := filepath.Join(destPath, name)
-		if err := os.Rename(src, dst); err != nil {
+		if err := robustRename(src, dst); err != nil {
 			return fmt.Errorf("restoring %s: %w", name, err)
 		}
 	}

--- a/glx/fileops.go
+++ b/glx/fileops.go
@@ -232,7 +232,7 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	if err := os.Chmod(tmpPath, perm); err != nil {
 		return fmt.Errorf("setting file permissions: %w", err)
 	}
-	if err := os.Rename(tmpPath, path); err != nil {
+	if err := robustRename(tmpPath, path); err != nil {
 		return fmt.Errorf("replacing target file: %w", err)
 	}
 

--- a/glx/robustio_other.go
+++ b/glx/robustio_other.go
@@ -16,7 +16,9 @@
 
 package main
 
-import "os"
+import (
+	"os"
+)
 
 // robustRename is like os.Rename. On non-Windows platforms, rename is atomic
 // and does not suffer from transient file locking, so no retry is needed.

--- a/glx/robustio_other.go
+++ b/glx/robustio_other.go
@@ -1,0 +1,25 @@
+// Copyright 2025 Oracynth, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package main
+
+import "os"
+
+// robustRename is like os.Rename. On non-Windows platforms, rename is atomic
+// and does not suffer from transient file locking, so no retry is needed.
+func robustRename(oldpath, newpath string) error {
+	return os.Rename(oldpath, newpath)
+}

--- a/glx/robustio_windows.go
+++ b/glx/robustio_windows.go
@@ -30,20 +30,24 @@ const errSharingViolation syscall.Errno = 32 //nolint:mnd // Windows error code
 
 const retryTimeout = 2000 * time.Millisecond //nolint:mnd // matches Go toolchain robustio
 
+const maxSleep = 500 * time.Millisecond //nolint:mnd // cap per-retry sleep
+
 // robustRename is like os.Rename but retries on transient Windows errors.
 //
 // Windows Defender, Search Indexer, OneDrive, and other processes can briefly
 // hold file handles without FILE_SHARE_DELETE, causing MoveFileEx to fail with
 // ERROR_ACCESS_DENIED or ERROR_SHARING_VIOLATION. These locks are transient —
-// retrying with backoff resolves them.
+// retrying with exponential backoff resolves them.
+//
+// Backoff: 1ms, 2ms, 4ms, 8ms, ... up to 500ms per sleep, 2s total timeout.
+// Jitter added to each sleep to avoid synchronized retries.
 //
 // Modeled after Go's cmd/internal/robustio (used by cmd/go, gopls, golangci-lint).
 func robustRename(oldpath, newpath string) error {
 	var (
-		bestErr     error
-		lowestErrno syscall.Errno
-		start       time.Time
-		nextSleep   = 1 * time.Millisecond
+		lastErr   error
+		start     time.Time
+		nextSleep = 1 * time.Millisecond
 	)
 
 	for {
@@ -52,12 +56,7 @@ func robustRename(oldpath, newpath string) error {
 			return err
 		}
 
-		if errno, ok := errors.AsType[syscall.Errno](err); ok && (lowestErrno == 0 || errno < lowestErrno) {
-			bestErr = err
-			lowestErrno = errno
-		} else if bestErr == nil {
-			bestErr = err
-		}
+		lastErr = err
 
 		if start.IsZero() {
 			start = time.Now()
@@ -66,10 +65,12 @@ func robustRename(oldpath, newpath string) error {
 		}
 
 		time.Sleep(nextSleep)
-		nextSleep += time.Duration(rand.Int63n(int64(nextSleep))) //nolint:gosec // jitter, not crypto
+
+		// Exponential backoff: double the base, add jitter, cap at maxSleep
+		nextSleep = min(nextSleep*2+time.Duration(rand.Int63n(int64(nextSleep))), maxSleep) //nolint:gosec // jitter, not crypto
 	}
 
-	return bestErr
+	return lastErr
 }
 
 // isEphemeralError returns true if err is a transient Windows filesystem error

--- a/glx/robustio_windows.go
+++ b/glx/robustio_windows.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Oracynth, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"math/rand"
+	"os"
+	"syscall"
+	"time"
+)
+
+// errSharingViolation is syscall.Errno(32), equivalent to
+// internal/syscall/windows.ERROR_SHARING_VIOLATION which is not importable.
+const errSharingViolation syscall.Errno = 32 //nolint:mnd // Windows error code
+
+const retryTimeout = 2000 * time.Millisecond //nolint:mnd // matches Go toolchain robustio
+
+// robustRename is like os.Rename but retries on transient Windows errors.
+//
+// Windows Defender, Search Indexer, OneDrive, and other processes can briefly
+// hold file handles without FILE_SHARE_DELETE, causing MoveFileEx to fail with
+// ERROR_ACCESS_DENIED or ERROR_SHARING_VIOLATION. These locks are transient —
+// retrying with backoff resolves them.
+//
+// Modeled after Go's cmd/internal/robustio (used by cmd/go, gopls, golangci-lint).
+func robustRename(oldpath, newpath string) error {
+	var (
+		bestErr     error
+		lowestErrno syscall.Errno
+		start       time.Time
+		nextSleep   = 1 * time.Millisecond
+	)
+
+	for {
+		err := os.Rename(oldpath, newpath)
+		if err == nil || !isEphemeralError(err) {
+			return err
+		}
+
+		if errno, ok := errors.AsType[syscall.Errno](err); ok && (lowestErrno == 0 || errno < lowestErrno) {
+			bestErr = err
+			lowestErrno = errno
+		} else if bestErr == nil {
+			bestErr = err
+		}
+
+		if start.IsZero() {
+			start = time.Now()
+		} else if time.Since(start)+nextSleep >= retryTimeout {
+			break
+		}
+
+		time.Sleep(nextSleep)
+		nextSleep += time.Duration(rand.Int63n(int64(nextSleep))) //nolint:gosec // jitter, not crypto
+	}
+
+	return bestErr
+}
+
+// isEphemeralError returns true if err is a transient Windows filesystem error
+// that may resolve by waiting.
+func isEphemeralError(err error) bool {
+	if errno, ok := errors.AsType[syscall.Errno](err); ok {
+		switch errno {
+		case syscall.ERROR_ACCESS_DENIED,
+			syscall.ERROR_FILE_NOT_FOUND,
+			errSharingViolation:
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
## Summary

- Adds `robustRename` wrapper modeled after Go toolchain's `cmd/internal/robustio` (used by `cmd/go`, `gopls`, `golangci-lint`)
- Retries `os.Rename` on transient Windows errors (`ERROR_ACCESS_DENIED`, `ERROR_SHARING_VIOLATION`, `ERROR_FILE_NOT_FOUND`) with randomized exponential backoff (1ms initial, 2s cap)
- On non-Windows: direct passthrough to `os.Rename` (no overhead)
- Replaces `os.Rename` in `safeWriteMultiFileArchive` (3 calls), `restoreForeignEntries` (1 call), and `atomicWriteFile` (1 call)
- `TestSafeWriteMultiFileArchive` now passes 20/20 runs on Windows (previously failed 50-80%)

Fixes #698
Fixes #700

## Test plan

- [x] `TestSafeWriteMultiFileArchive` — 20/20 passes on Windows 11 with `-count=20` (previously failed 10-16/20)
- [x] All existing tests pass (`go test ./glx/... ./go-glx/...`)
- [x] No new lint issues (`golangci-lint run --new-from-rev=HEAD`)
- [x] Non-Windows passthrough compiles (build-tagged `//go:build !windows`)