### PR TITLE
chore: upgrade govulncheck-action to fix cache 400 errors

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -39,7 +39,7 @@ jobs:
         run: go mod download
 
       - name: Run govulncheck
-        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        uses: golang/govulncheck-action@31f7c5463448f83528bd771c2d978d940080c9fd # master 2026-02-26
         with:
           repo-checkout: false
           go-version-input: '1.26'


### PR DESCRIPTION
## Summary

- Updates `golang/govulncheck-action` from `v1.0.4` (`b625fbe0`) to master HEAD (`31f7c546`)
- Fixes "Cache service responded with 400" warnings caused by the legacy GitHub Actions cache service being sunset
- v1.0.4 bundled `actions/setup-go@v5.0.0` with `@actions/cache` v3 (legacy service)
- Master HEAD bundles `actions/setup-go@v6.2.0` with `@actions/cache` v5 (new service)

Fixes #709

## Test plan

- [x] CI should pass with the updated action
- [x] govulncheck job should no longer show "Cache service responded with 400" warning
