### PR TITLE
feat: Split gender property into sex (recorded) and gender (identity)

### DIFF
--- a/.claude/commands/check-code-drift.md
+++ b/.claude/commands/check-code-drift.md
@@ -126,11 +126,11 @@ Compare Go types with JSON schema types:
 - Check that GLXFile struct has all entity type maps
 - Verify yaml tags match schema (e.g., `persons`, `events`, etc.)
 - Check `ImportMetadata *Metadata` field against `metadata` property in schema (Go field name differs from yaml tag)
-- Check all vocabulary definition maps (9 type vocabs + 8 property vocabs)
+- Check all vocabulary definition maps (10 type vocabs + 8 property vocabs)
 
 ### 8. Vocabulary Struct Types
 
-Check all 9 vocabulary definition structs against their schemas in
+Check all 10 vocabulary definition structs against their schemas in
 `specification/schema/v1/vocabularies/`:
 
 | Go Struct | Schema File | Key Fields |

--- a/.claude/commands/check-code-drift.md
+++ b/.claude/commands/check-code-drift.md
@@ -141,6 +141,7 @@ Check all 9 vocabulary definition structs against their schemas in
 | `SourceType` | `source-types.schema.json` | Label, Description, GEDCOM |
 | `RepositoryType` | `repository-types.schema.json` | Label, Description, GEDCOM |
 | `MediaType` | `media-types.schema.json` | Label, Description, MimeType |
+| `SexType` | `sex-types.schema.json` | Label, Description, GEDCOM |
 | `GenderType` | `gender-types.schema.json` | Label, Description, GEDCOM |
 | `ConfidenceLevel` | `confidence-levels.schema.json` | Label, Description, GEDCOM |
 | `ParticipantRole` | `participant-roles.schema.json` | Label, Description, GEDCOM, AppliesTo |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Changed
+
+#### Specification
+- **Split `gender` property into `sex` (recorded) and `gender` (identity)** — The existing `gender` property conflated "recorded sex" (GEDCOM `SEX`) with "self-identified gender identity". Introduced a new `sex_types` vocabulary (`male`, `female`, `unknown`, `not_recorded`, `other`) bound to a renamed `sex` person property that maps to GEDCOM `SEX`. The `gender_types` vocabulary now covers identity values (`male`, `female`, `nonbinary`, `other`) bound to a new optional `gender` property (no direct GEDCOM mapping — GEDCOM 7.0 defers identity to `FACT`). GEDCOM import/export, HUSB/WIFE assignment, census parsing, and CLI readers (`vitals`, `summary`) all updated to use `sex`. Archives predating this split can be migrated automatically via `glx migrate --rename-gender-to-sex`. Resolves #528, closes #518, #534, #545.
+
+### Added
+
+#### CLI
+- **`glx migrate --rename-gender-to-sex`** — New opt-in flag on `glx migrate` that renames the legacy `gender` person property (and related assertions and inlined vocabulary entries) to `sex`, completing the two-field-model split in pre-v1.0 archives (#528).
+
 ### Fixed
 
 #### go-glx

--- a/docs/examples/assertion-workflow/archive.glx
+++ b/docs/examples/assertion-workflow/archive.glx
@@ -47,7 +47,7 @@ persons:
         fields:
           given: "Alice"
           surname: "Chen"
-      gender: "female"
+      sex: "female"
       occupation: "software engineer"
       residence: "place-cambridge"
     notes: |
@@ -65,7 +65,7 @@ persons:
         fields:
           given: "Robert"
           surname: "Chen"
-      gender: "male"
+      sex: "male"
       # Temporal occupation (changed over time)
       occupation:
         - value: "accountant"

--- a/docs/examples/basic-family/README.md
+++ b/docs/examples/basic-family/README.md
@@ -44,7 +44,7 @@ persons:
         fields:
           given: "Mary"
           surname: "Thompson"
-      gender: female
+      sex: female
 ```
 
 ### persons/person-father.glx
@@ -57,7 +57,7 @@ persons:
         fields:
           given: "Robert"
           surname: "Thompson"
-      gender: male
+      sex: male
 ```
 
 ### persons/person-child-alice.glx
@@ -70,7 +70,7 @@ persons:
         fields:
           given: "Alice"
           surname: "Thompson"
-      gender: female
+      sex: female
 ```
 
 ### persons/person-child-bob.glx
@@ -83,7 +83,7 @@ persons:
         fields:
           given: "Robert"
           surname: "Thompson"
-      gender: male
+      sex: male
 ```
 
 ### relationships/rel-marriage.glx

--- a/docs/examples/basic-family/persons/person-child-alice.glx
+++ b/docs/examples/basic-family/persons/person-child-alice.glx
@@ -6,4 +6,4 @@ persons:
         fields:
           given: "Alice"
           surname: "Thompson"
-      gender: female
+      sex: female

--- a/docs/examples/basic-family/persons/person-child-bob.glx
+++ b/docs/examples/basic-family/persons/person-child-bob.glx
@@ -6,4 +6,4 @@ persons:
         fields:
           given: "Robert"
           surname: "Thompson"
-      gender: male
+      sex: male

--- a/docs/examples/basic-family/persons/person-father.glx
+++ b/docs/examples/basic-family/persons/person-father.glx
@@ -6,4 +6,4 @@ persons:
         fields:
           given: "Robert"
           surname: "Thompson"
-      gender: male
+      sex: male

--- a/docs/examples/basic-family/persons/person-mother.glx
+++ b/docs/examples/basic-family/persons/person-mother.glx
@@ -6,4 +6,4 @@ persons:
         fields:
           given: "Mary"
           surname: "Thompson"
-      gender: female
+      sex: female

--- a/docs/examples/complete-family/README.md
+++ b/docs/examples/complete-family/README.md
@@ -101,7 +101,7 @@ persons:
         fields:
           given: "John"
           surname: "Smith"
-      gender: "male"
+      sex: "male"
 ```
 
 **Key Points:**

--- a/docs/examples/complete-family/persons/person-jane-smith.glx
+++ b/docs/examples/complete-family/persons/person-jane-smith.glx
@@ -6,5 +6,5 @@ persons:
         fields:
           given: "Jane"
           surname: "Smith"
-      gender: "female"
+      sex: "female"
     notes: "Daughter of John Smith and Mary Brown."

--- a/docs/examples/complete-family/persons/person-john-smith.glx
+++ b/docs/examples/complete-family/persons/person-john-smith.glx
@@ -6,5 +6,5 @@ persons:
         fields:
           given: "John"
           surname: "Smith"
-      gender: "male"
+      sex: "male"
     notes: "Blacksmith in Leeds, Yorkshire. Married Mary Brown in 1875."

--- a/docs/examples/complete-family/persons/person-mary-brown.glx
+++ b/docs/examples/complete-family/persons/person-mary-brown.glx
@@ -14,5 +14,5 @@ persons:
             type: "married"
             given: "Mary"
             surname: "Smith"
-      gender: "female"
+      sex: "female"
     notes: "Wife of John Smith. Dressmaker by trade."

--- a/docs/examples/participant-assertions/archive.glx
+++ b/docs/examples/participant-assertions/archive.glx
@@ -10,7 +10,7 @@ persons:
         fields:
           given: "John"
           surname: "Smith"
-      gender: "male"
+      sex: "male"
 
   person-jane-doe:
     properties:
@@ -19,7 +19,7 @@ persons:
         fields:
           given: "Jane"
           surname: "Doe"
-      gender: "female"
+      sex: "female"
 
   person-thomas-brown:
     properties:
@@ -28,7 +28,7 @@ persons:
         fields:
           given: "Thomas"
           surname: "Brown"
-      gender: "male"
+      sex: "male"
 
 events:
   event-marriage-1880:

--- a/docs/examples/single-file/archive.glx
+++ b/docs/examples/single-file/archive.glx
@@ -69,7 +69,7 @@ confidence_levels:
     label: "High Confidence"
     description: "Strong evidence with minimal doubt"
 
-gender_types:
+sex_types:
   male:
     label: "Male"
     gedcom: "M"
@@ -113,10 +113,10 @@ person_properties:
         label: "Suffix"
         description: "Generational suffix (Jr., Sr., III)"
 
-  gender:
-    label: "Gender"
-    description: "Gender identity"
-    vocabulary_type: gender_types
+  sex:
+    label: "Sex"
+    description: "Sex as recorded in source documents"
+    vocabulary_type: sex_types
 
 source_properties:
   url:
@@ -147,7 +147,7 @@ persons:
           type: "birth"
           given: "John"
           surname: "Smith"
-      gender: "male"
+      sex: "male"
 
   person-b2c3d4e5:
     properties:
@@ -157,7 +157,7 @@ persons:
           type: "birth"
           given: "Mary"
           surname: "Brown"
-      gender: "female"
+      sex: "female"
 
 relationships:
   rel-12345678:

--- a/docs/examples/temporal-properties/archive.glx
+++ b/docs/examples/temporal-properties/archive.glx
@@ -25,7 +25,7 @@ persons:
             given: "John"
             surname: "Smith"
 
-      gender: "male"
+      sex: "male"
 
       # Occupations throughout life
       occupation:

--- a/docs/guides/hands-on-cli-guide.md
+++ b/docs/guides/hands-on-cli-guide.md
@@ -596,7 +596,7 @@ glx census add --from 1860-census-stark.yaml --archive .
 The generated assertions include:
 - **Birth year** (ABT, low confidence) — estimated from age
 - **Birthplace** (medium confidence) — resolved against existing places
-- **Gender** (high confidence) — directly stated
+- **Sex** (high confidence) — directly stated
 - **Occupation** (high confidence, dated) — directly stated
 - **Residence** (high confidence, dated) — enumerated at this place
 

--- a/docs/guides/migration-from-gedcom.md
+++ b/docs/guides/migration-from-gedcom.md
@@ -114,7 +114,7 @@ Import statistics:
 
 The importer processes records in dependency order across multiple passes, handling all standard GEDCOM record types.
 
-**Individuals**: Names (with parsed components), sex (with optional gender identity), 20+ event types, 8+ property types, external IDs, notes, media references
+**Individuals**: Names (with parsed components), sex, 20+ event types, 8+ property types, external IDs, notes, media references
 
 **Events**: Each imported event receives an auto-generated `title` field for human readability. The format varies by event type:
 - Individual events: "Birth of Robert Webb (1815)"

--- a/docs/guides/migration-from-gedcom.md
+++ b/docs/guides/migration-from-gedcom.md
@@ -114,7 +114,7 @@ Import statistics:
 
 The importer processes records in dependency order across multiple passes, handling all standard GEDCOM record types.
 
-**Individuals**: Names (with parsed components), gender, 20+ event types, 8+ property types, external IDs, notes, media references
+**Individuals**: Names (with parsed components), sex (with optional gender identity), 20+ event types, 8+ property types, external IDs, notes, media references
 
 **Events**: Each imported event receives an auto-generated `title` field for human readability. The format varies by event type:
 - Individual events: "Birth of Robert Webb (1815)"
@@ -183,7 +183,7 @@ Relative file paths in the GEDCOM are resolved from the directory containing the
 | GEDCOM Tag | GLX Property | Notes |
 |------------|-------------|-------|
 | `NAME` | `name` | Parsed into structured fields (see [Name Conversion](#name-conversion)) |
-| `SEX` | `gender` | M→male, F→female, U→unknown, X→other |
+| `SEX` | `sex` | M→male, F→female, U→unknown, X→other |
 | `OCCU` | `occupation` | Temporal property |
 | `RELI` | `religion` | |
 | `EDUC` | `education` | |

--- a/glx/README.md
+++ b/glx/README.md
@@ -1123,7 +1123,7 @@ glx census add --from <template.yaml> [flags]
 - **Source** — new or reused by title match
 - **Citation** — with locator, text_from_source, URL, accessed date
 - **Place** — new or reused by name match
-- **Assertions** — birth year (ABT, low confidence), birthplace (medium), gender (high), occupation (high, dated), residence (high, dated), custom properties
+- **Assertions** — birth year (ABT, low confidence), birthplace (medium), sex (high), occupation (high, dated), residence (high, dated), custom properties
 
 **Template format:**
 ```yaml

--- a/glx/archive_io.go
+++ b/glx/archive_io.go
@@ -331,6 +331,9 @@ func mergeStandardVocabularies(glx *glxlib.GLXFile) error {
 	if len(glx.ConfidenceLevels) == 0 {
 		glx.ConfidenceLevels = std.ConfidenceLevels
 	}
+	if len(glx.SexTypes) == 0 {
+		glx.SexTypes = std.SexTypes
+	}
 	if len(glx.GenderTypes) == 0 {
 		glx.GenderTypes = std.GenderTypes
 	}

--- a/glx/cli_commands.go
+++ b/glx/cli_commands.go
@@ -880,7 +880,7 @@ Reads a YAML census template and generates:
 - A census event with participants
 - A source (new or matched to existing)
 - A citation with locator, URL, transcription
-- Assertions for birth year, birthplace, gender, occupation, residence
+- Assertions for birth year, birthplace, sex, occupation, residence
 
 The template format uses a simple YAML structure describing the census
 year, location, household members, and citation details. Members can

--- a/glx/cmd_migrate.go
+++ b/glx/cmd_migrate.go
@@ -23,6 +23,8 @@ import (
 	glxlib "github.com/genealogix/glx/go-glx"
 )
 
+var migrateRenameGenderToSex bool
+
 var migrateCmd = &cobra.Command{
 	Use:   "migrate [archive]",
 	Short: "Migrate an archive to the current format",
@@ -32,14 +34,26 @@ For each person with deprecated properties:
 - Creates a birth, death, or burial event if none exists
 - Merges date/place into existing events if fields are empty
 - Never overwrites existing event data
-- Converts assertions to reference the event instead of the person property`,
+- Converts assertions to reference the event instead of the person property
+
+With --rename-gender-to-sex, also renames the legacy ` + "`gender`" + ` person
+property (and any related assertions and inlined vocabulary entries) to
+` + "`sex`" + `, completing the two-field-model split introduced in #528.`,
 	Example: `  # Migrate a multi-file archive
   glx migrate ./my-archive
 
   # Migrate a single-file archive
-  glx migrate archive.glx`,
+  glx migrate archive.glx
+
+  # Also rename legacy 'gender' person properties to 'sex'
+  glx migrate ./my-archive --rename-gender-to-sex`,
 	Args: cobra.ExactArgs(1),
 	RunE: runMigrate,
+}
+
+func init() {
+	migrateCmd.Flags().BoolVar(&migrateRenameGenderToSex, "rename-gender-to-sex", false,
+		"Rename the legacy 'gender' person property to 'sex' (two-field-model split, #528)")
 }
 
 func runMigrate(_ *cobra.Command, args []string) error {
@@ -78,9 +92,21 @@ func migrateArchive(archivePath string) error {
 		return fmt.Errorf("migration failed: %w", err)
 	}
 
+	if migrateRenameGenderToSex {
+		genderReport, err := migrateGenderToSex(archive, os.Stderr)
+		if err != nil {
+			return fmt.Errorf("gender→sex migration failed: %w", err)
+		}
+		report.PropertiesRenamed += genderReport.PropertiesRenamed
+		report.AssertionsRenamed += genderReport.AssertionsRenamed
+		report.VocabEntriesRenamed += genderReport.VocabEntriesRenamed
+	}
+
 	if report.EventsCreated == 0 && report.EventsMerged == 0 &&
 		report.PropertiesRemoved == 0 && report.AssertionsMigrated == 0 &&
-		report.VocabEntriesRemoved == 0 {
+		report.VocabEntriesRemoved == 0 &&
+		report.PropertiesRenamed == 0 && report.AssertionsRenamed == 0 &&
+		report.VocabEntriesRenamed == 0 {
 		fmt.Println("No deprecated properties found. Archive is already up to date.")
 		return nil
 	}
@@ -97,11 +123,16 @@ func migrateArchive(archivePath string) error {
 	}
 
 	fmt.Println("Migration complete:")
-	fmt.Printf("  Events created:       %d\n", report.EventsCreated)
-	fmt.Printf("  Events merged:        %d\n", report.EventsMerged)
-	fmt.Printf("  Properties removed:   %d\n", report.PropertiesRemoved)
-	fmt.Printf("  Assertions migrated:  %d\n", report.AssertionsMigrated)
-	fmt.Printf("  Vocab entries removed: %d\n", report.VocabEntriesRemoved)
+	fmt.Printf("  Events created:          %d\n", report.EventsCreated)
+	fmt.Printf("  Events merged:           %d\n", report.EventsMerged)
+	fmt.Printf("  Properties removed:      %d\n", report.PropertiesRemoved)
+	fmt.Printf("  Assertions migrated:     %d\n", report.AssertionsMigrated)
+	fmt.Printf("  Vocab entries removed:   %d\n", report.VocabEntriesRemoved)
+	if migrateRenameGenderToSex {
+		fmt.Printf("  Gender→sex properties:   %d\n", report.PropertiesRenamed)
+		fmt.Printf("  Gender→sex assertions:   %d\n", report.AssertionsRenamed)
+		fmt.Printf("  Gender→sex vocab entries: %d\n", report.VocabEntriesRenamed)
+	}
 
 	return nil
 }

--- a/glx/cmd_migrate.go
+++ b/glx/cmd_migrate.go
@@ -93,10 +93,7 @@ func migrateArchive(archivePath string) error {
 	}
 
 	if migrateRenameGenderToSex {
-		genderReport, err := migrateGenderToSex(archive, os.Stderr)
-		if err != nil {
-			return fmt.Errorf("gender→sex migration failed: %w", err)
-		}
+		genderReport := migrateGenderToSex(archive, os.Stderr)
 		report.PropertiesRenamed += genderReport.PropertiesRenamed
 		report.AssertionsRenamed += genderReport.AssertionsRenamed
 		report.VocabEntriesRenamed += genderReport.VocabEntriesRenamed

--- a/glx/migrate_gender_runner.go
+++ b/glx/migrate_gender_runner.go
@@ -27,7 +27,7 @@ import (
 //
 // It is opt-in via `glx migrate --rename-gender-to-sex`. The archive is
 // mutated in place; the returned report counts the renames.
-func migrateGenderToSex(archive *glxlib.GLXFile, warnOut io.Writer) (*MigrateReport, error) {
+func migrateGenderToSex(archive *glxlib.GLXFile, warnOut io.Writer) *MigrateReport {
 	if warnOut == nil {
 		warnOut = io.Discard
 	}
@@ -40,7 +40,7 @@ func migrateGenderToSex(archive *glxlib.GLXFile, warnOut io.Writer) (*MigrateRep
 
 	archive.InvalidateCache()
 
-	return report, nil
+	return report
 }
 
 // renamePersonGenderProperties moves person.properties["gender"] → ["sex"]

--- a/glx/migrate_gender_runner.go
+++ b/glx/migrate_gender_runner.go
@@ -1,0 +1,102 @@
+// Copyright 2025 Oracynth, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io"
+
+	glxlib "github.com/genealogix/glx/go-glx"
+)
+
+// migrateGenderToSex renames the legacy `gender` person property to `sex`
+// (and updates related assertions and inlined vocabularies) so that archives
+// created before #528 align with the two-field-model split.
+//
+// It is opt-in via `glx migrate --rename-gender-to-sex`. The archive is
+// mutated in place; the returned report counts the renames. Person IDs are
+// iterated in sorted order so conflict warnings are deterministic.
+func migrateGenderToSex(archive *glxlib.GLXFile, warnOut io.Writer) (*MigrateReport, error) {
+	report := &MigrateReport{}
+
+	for _, personID := range sortedKeys(archive.Persons) {
+		person := archive.Persons[personID]
+		if person == nil || len(person.Properties) == 0 {
+			continue
+		}
+		val, hasGender := person.Properties[glxlib.PersonPropertyGender]
+		if !hasGender {
+			continue
+		}
+		if _, hasSex := person.Properties[glxlib.PersonPropertySex]; hasSex {
+			fmt.Fprintf(warnOut,
+				"Warning: person %q has both 'gender' and 'sex' properties; leaving 'gender' untouched\n",
+				personID)
+			continue
+		}
+		person.Properties[glxlib.PersonPropertySex] = val
+		delete(person.Properties, glxlib.PersonPropertyGender)
+		report.PropertiesRenamed++
+	}
+
+	for _, assertion := range archive.Assertions {
+		if assertion == nil {
+			continue
+		}
+		if assertion.Property == glxlib.PersonPropertyGender {
+			assertion.Property = glxlib.PersonPropertySex
+			report.AssertionsRenamed++
+		}
+	}
+
+	if archive.PersonProperties != nil {
+		if def, ok := archive.PersonProperties[glxlib.PersonPropertyGender]; ok && def != nil {
+			if _, sexExists := archive.PersonProperties[glxlib.PersonPropertySex]; !sexExists {
+				if def.VocabularyType == glxlib.VocabGenderTypes {
+					def.VocabularyType = glxlib.VocabSexTypes
+				}
+				archive.PersonProperties[glxlib.PersonPropertySex] = def
+				delete(archive.PersonProperties, glxlib.PersonPropertyGender)
+				report.VocabEntriesRenamed++
+			}
+		}
+	}
+
+	// Pre-split gender_types vocabulary (contains "unknown" but not "nonbinary")
+	// moves to sex_types to keep the archive self-contained after the rename.
+	if len(archive.GenderTypes) > 0 && len(archive.SexTypes) == 0 {
+		if _, hasUnknown := archive.GenderTypes["unknown"]; hasUnknown {
+			if _, hasNonbinary := archive.GenderTypes["nonbinary"]; !hasNonbinary {
+				archive.SexTypes = make(map[string]*glxlib.SexType, len(archive.GenderTypes))
+				for key, entry := range archive.GenderTypes {
+					if entry == nil {
+						continue
+					}
+					archive.SexTypes[key] = &glxlib.SexType{
+						Label:       entry.Label,
+						Description: entry.Description,
+						GEDCOM:      entry.GEDCOM,
+					}
+				}
+				archive.GenderTypes = nil
+				report.VocabEntriesRenamed++
+			}
+		}
+	}
+
+	archive.InvalidateCache()
+
+	return report, nil
+}

--- a/glx/migrate_gender_runner.go
+++ b/glx/migrate_gender_runner.go
@@ -157,11 +157,17 @@ func renamePersonGenderProperties(archive *glxlib.GLXFile, warnOut io.Writer) in
 	return count
 }
 
-// renameGenderAssertions flips assertion.Property from "gender" to "sex".
+// renameGenderAssertions flips assertion.Property from "gender" to "sex"
+// only for assertions whose subject is a person. Non-person subjects (events,
+// relationships, etc.) may legitimately use a custom `gender` property and
+// must not be touched by this migration.
 func renameGenderAssertions(archive *glxlib.GLXFile) int {
 	count := 0
 	for _, assertion := range archive.Assertions {
 		if assertion == nil {
+			continue
+		}
+		if assertion.Subject.Person == "" {
 			continue
 		}
 		if assertion.Property == glxlib.PersonPropertyGender {

--- a/glx/migrate_gender_runner.go
+++ b/glx/migrate_gender_runner.go
@@ -28,11 +28,15 @@ import (
 // It is opt-in via `glx migrate --rename-gender-to-sex`. The archive is
 // mutated in place; the returned report counts the renames.
 //
-// Legacy detection: the rename is skipped entirely on archives that already
-// carry post-split schema (a `sex` person-property definition, or inlined
-// `gender_types` with a `nonbinary` entry). In post-split archives `gender`
-// means identity, and treating it as sex would silently corrupt identity
-// data.
+// Legacy detection: the rename is skipped entirely when the archive already
+// carries post-split person data or assertions — a person with
+// `properties.sex` set, a person with `gender == "nonbinary"`, or an
+// assertion targeting `sex` or `gender == "nonbinary"`. Vocabulary-only
+// signals are intentionally ignored because `mergeStandardVocabularies`
+// unconditionally populates `sex_types` and the post-split
+// `person_properties` at load time, so those would always look post-split.
+// In post-split archives `gender` means identity, and treating it as sex
+// would silently corrupt identity data.
 func migrateGenderToSex(archive *glxlib.GLXFile, warnOut io.Writer) *MigrateReport {
 	if warnOut == nil {
 		warnOut = io.Discard

--- a/glx/migrate_gender_runner.go
+++ b/glx/migrate_gender_runner.go
@@ -26,11 +26,28 @@ import (
 // created before #528 align with the two-field-model split.
 //
 // It is opt-in via `glx migrate --rename-gender-to-sex`. The archive is
-// mutated in place; the returned report counts the renames. Person IDs are
-// iterated in sorted order so conflict warnings are deterministic.
+// mutated in place; the returned report counts the renames.
 func migrateGenderToSex(archive *glxlib.GLXFile, warnOut io.Writer) (*MigrateReport, error) {
+	if warnOut == nil {
+		warnOut = io.Discard
+	}
 	report := &MigrateReport{}
 
+	report.PropertiesRenamed = renamePersonGenderProperties(archive, warnOut)
+	report.AssertionsRenamed = renameGenderAssertions(archive)
+	report.VocabEntriesRenamed = renamePersonPropertyDefinition(archive) +
+		movePreSplitGenderTypesVocab(archive)
+
+	archive.InvalidateCache()
+
+	return report, nil
+}
+
+// renamePersonGenderProperties moves person.properties["gender"] → ["sex"]
+// when "sex" is absent. Person IDs are iterated in sorted order so conflict
+// warnings are deterministic.
+func renamePersonGenderProperties(archive *glxlib.GLXFile, warnOut io.Writer) int {
+	count := 0
 	for _, personID := range sortedKeys(archive.Persons) {
 		person := archive.Persons[personID]
 		if person == nil || len(person.Properties) == 0 {
@@ -41,62 +58,90 @@ func migrateGenderToSex(archive *glxlib.GLXFile, warnOut io.Writer) (*MigrateRep
 			continue
 		}
 		if _, hasSex := person.Properties[glxlib.PersonPropertySex]; hasSex {
-			fmt.Fprintf(warnOut,
+			_, _ = fmt.Fprintf(warnOut,
 				"Warning: person %q has both 'gender' and 'sex' properties; leaving 'gender' untouched\n",
 				personID)
+
 			continue
 		}
 		person.Properties[glxlib.PersonPropertySex] = val
 		delete(person.Properties, glxlib.PersonPropertyGender)
-		report.PropertiesRenamed++
+		count++
 	}
 
+	return count
+}
+
+// renameGenderAssertions flips assertion.Property from "gender" to "sex".
+func renameGenderAssertions(archive *glxlib.GLXFile) int {
+	count := 0
 	for _, assertion := range archive.Assertions {
 		if assertion == nil {
 			continue
 		}
 		if assertion.Property == glxlib.PersonPropertyGender {
 			assertion.Property = glxlib.PersonPropertySex
-			report.AssertionsRenamed++
+			count++
 		}
 	}
 
-	if archive.PersonProperties != nil {
-		if def, ok := archive.PersonProperties[glxlib.PersonPropertyGender]; ok && def != nil {
-			if _, sexExists := archive.PersonProperties[glxlib.PersonPropertySex]; !sexExists {
-				if def.VocabularyType == glxlib.VocabGenderTypes {
-					def.VocabularyType = glxlib.VocabSexTypes
-				}
-				archive.PersonProperties[glxlib.PersonPropertySex] = def
-				delete(archive.PersonProperties, glxlib.PersonPropertyGender)
-				report.VocabEntriesRenamed++
-			}
-		}
+	return count
+}
+
+// renamePersonPropertyDefinition renames person_properties["gender"] →
+// ["sex"] when "sex" is absent, also flipping its vocabulary_type.
+func renamePersonPropertyDefinition(archive *glxlib.GLXFile) int {
+	if archive.PersonProperties == nil {
+		return 0
+	}
+	def, ok := archive.PersonProperties[glxlib.PersonPropertyGender]
+	if !ok || def == nil {
+		return 0
+	}
+	if _, sexExists := archive.PersonProperties[glxlib.PersonPropertySex]; sexExists {
+		return 0
+	}
+	if def.VocabularyType == glxlib.VocabGenderTypes {
+		def.VocabularyType = glxlib.VocabSexTypes
+	}
+	archive.PersonProperties[glxlib.PersonPropertySex] = def
+	delete(archive.PersonProperties, glxlib.PersonPropertyGender)
+
+	return 1
+}
+
+// movePreSplitGenderTypesVocab moves an inlined pre-split gender_types
+// vocabulary (contains "unknown", lacks "nonbinary") to sex_types so the
+// archive stays self-contained after the rename. Existing sex_types entries
+// are preserved — only keys not already present are copied over.
+func movePreSplitGenderTypesVocab(archive *glxlib.GLXFile) int {
+	if len(archive.GenderTypes) == 0 {
+		return 0
+	}
+	if _, hasUnknown := archive.GenderTypes["unknown"]; !hasUnknown {
+		return 0
+	}
+	if _, hasNonbinary := archive.GenderTypes["nonbinary"]; hasNonbinary {
+		return 0
 	}
 
-	// Pre-split gender_types vocabulary (contains "unknown" but not "nonbinary")
-	// moves to sex_types to keep the archive self-contained after the rename.
-	if len(archive.GenderTypes) > 0 && len(archive.SexTypes) == 0 {
-		if _, hasUnknown := archive.GenderTypes["unknown"]; hasUnknown {
-			if _, hasNonbinary := archive.GenderTypes["nonbinary"]; !hasNonbinary {
-				archive.SexTypes = make(map[string]*glxlib.SexType, len(archive.GenderTypes))
-				for key, entry := range archive.GenderTypes {
-					if entry == nil {
-						continue
-					}
-					archive.SexTypes[key] = &glxlib.SexType{
-						Label:       entry.Label,
-						Description: entry.Description,
-						GEDCOM:      entry.GEDCOM,
-					}
-				}
-				archive.GenderTypes = nil
-				report.VocabEntriesRenamed++
-			}
+	if archive.SexTypes == nil {
+		archive.SexTypes = make(map[string]*glxlib.SexType, len(archive.GenderTypes))
+	}
+	for key, entry := range archive.GenderTypes {
+		if entry == nil {
+			continue
+		}
+		if _, exists := archive.SexTypes[key]; exists {
+			continue
+		}
+		archive.SexTypes[key] = &glxlib.SexType{
+			Label:       entry.Label,
+			Description: entry.Description,
+			GEDCOM:      entry.GEDCOM,
 		}
 	}
+	archive.GenderTypes = nil
 
-	archive.InvalidateCache()
-
-	return report, nil
+	return 1
 }

--- a/glx/migrate_gender_runner.go
+++ b/glx/migrate_gender_runner.go
@@ -27,11 +27,26 @@ import (
 //
 // It is opt-in via `glx migrate --rename-gender-to-sex`. The archive is
 // mutated in place; the returned report counts the renames.
+//
+// Legacy detection: the rename is skipped entirely on archives that already
+// carry post-split schema (a `sex` person-property definition, or inlined
+// `gender_types` with a `nonbinary` entry). In post-split archives `gender`
+// means identity, and treating it as sex would silently corrupt identity
+// data.
 func migrateGenderToSex(archive *glxlib.GLXFile, warnOut io.Writer) *MigrateReport {
 	if warnOut == nil {
 		warnOut = io.Discard
 	}
 	report := &MigrateReport{}
+
+	if isPostSplitArchive(archive) {
+		_, _ = fmt.Fprintln(warnOut,
+			"Warning: archive appears to already use the post-split two-field model "+
+				"(sex/gender) — skipping --rename-gender-to-sex. Running this migration "+
+				"on a post-split archive would corrupt gender-identity data.")
+
+		return report
+	}
 
 	report.PropertiesRenamed = renamePersonGenderProperties(archive, warnOut)
 	report.AssertionsRenamed = renameGenderAssertions(archive)
@@ -41,6 +56,76 @@ func migrateGenderToSex(archive *glxlib.GLXFile, warnOut io.Writer) *MigrateRepo
 	archive.InvalidateCache()
 
 	return report
+}
+
+// isPostSplitArchive returns true when the archive carries data that is
+// clearly post-#528 (two-field model already in use). Vocabulary presence is
+// NOT a reliable signal — `LoadArchiveWithOptions` merges standard
+// vocabularies at load time, so both `sex_types` and the post-split
+// `person_properties` are always populated by that point. We look at actual
+// person data and assertions instead:
+//
+//   - Any person has a `sex` property set (someone is already using the new
+//     field — treating their `gender` values as sex would corrupt identity
+//     data).
+//   - Any person has a `gender` value of `nonbinary` (only exists in the
+//     post-split gender vocabulary).
+//   - Any assertion targets the `sex` property, or asserts `gender =
+//     nonbinary`.
+func isPostSplitArchive(archive *glxlib.GLXFile) bool {
+	for _, person := range archive.Persons {
+		if person == nil {
+			continue
+		}
+		if _, hasSex := person.Properties[glxlib.PersonPropertySex]; hasSex {
+			return true
+		}
+		if isIdentityOnlyGenderValue(person.Properties[glxlib.PersonPropertyGender]) {
+			return true
+		}
+	}
+	for _, assertion := range archive.Assertions {
+		if assertion == nil {
+			continue
+		}
+		if assertion.Property == glxlib.PersonPropertySex {
+			return true
+		}
+		if assertion.Property == glxlib.PersonPropertyGender &&
+			assertion.Value == glxlib.GenderNonbinary {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isIdentityOnlyGenderValue reports whether a gender property value contains
+// `nonbinary` — the canonical "only exists post-split" marker. Handles the
+// string, single-temporal-object, and temporal-list shapes a property can
+// take.
+func isIdentityOnlyGenderValue(val any) bool {
+	switch v := val.(type) {
+	case string:
+		return v == glxlib.GenderNonbinary
+	case map[string]any:
+		if s, ok := v["value"].(string); ok {
+			return s == glxlib.GenderNonbinary
+		}
+	case []any:
+		for _, item := range v {
+			if s, ok := item.(string); ok && s == glxlib.GenderNonbinary {
+				return true
+			}
+			if m, ok := item.(map[string]any); ok {
+				if s, ok := m["value"].(string); ok && s == glxlib.GenderNonbinary {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
 }
 
 // renamePersonGenderProperties moves person.properties["gender"] → ["sex"]

--- a/glx/migrate_gender_runner_test.go
+++ b/glx/migrate_gender_runner_test.go
@@ -32,8 +32,7 @@ func TestMigrateGenderToSex_PersonPropertyRename(t *testing.T) {
 		},
 	}
 
-	report, err := migrateGenderToSex(archive, &bytes.Buffer{})
-	require.NoError(t, err)
+	report := migrateGenderToSex(archive, &bytes.Buffer{})
 
 	assert.Equal(t, 2, report.PropertiesRenamed)
 	assert.Equal(t, "male", archive.Persons["person-1"].Properties["sex"])
@@ -53,8 +52,7 @@ func TestMigrateGenderToSex_AssertionRename(t *testing.T) {
 		},
 	}
 
-	report, err := migrateGenderToSex(archive, &bytes.Buffer{})
-	require.NoError(t, err)
+	report := migrateGenderToSex(archive, &bytes.Buffer{})
 
 	assert.Equal(t, 1, report.AssertionsRenamed)
 	assert.Equal(t, "sex", archive.Assertions["a-1"].Property)
@@ -71,8 +69,7 @@ func TestMigrateGenderToSex_VocabEntryRename(t *testing.T) {
 		},
 	}
 
-	report, err := migrateGenderToSex(archive, &bytes.Buffer{})
-	require.NoError(t, err)
+	report := migrateGenderToSex(archive, &bytes.Buffer{})
 
 	assert.Equal(t, 1, report.VocabEntriesRenamed)
 	require.Contains(t, archive.PersonProperties, "sex")
@@ -90,8 +87,7 @@ func TestMigrateGenderToSex_PreSplitGenderTypesMovedToSexTypes(t *testing.T) {
 		},
 	}
 
-	report, err := migrateGenderToSex(archive, &bytes.Buffer{})
-	require.NoError(t, err)
+	report := migrateGenderToSex(archive, &bytes.Buffer{})
 
 	assert.Equal(t, 1, report.VocabEntriesRenamed)
 	assert.Nil(t, archive.GenderTypes)
@@ -116,8 +112,7 @@ func TestMigrateGenderToSex_PreSplitMergesIntoExistingSexTypes(t *testing.T) {
 		},
 	}
 
-	report, err := migrateGenderToSex(archive, &bytes.Buffer{})
-	require.NoError(t, err)
+	report := migrateGenderToSex(archive, &bytes.Buffer{})
 
 	assert.Equal(t, 1, report.VocabEntriesRenamed)
 	assert.Nil(t, archive.GenderTypes)
@@ -134,8 +129,7 @@ func TestMigrateGenderToSex_NilWriterDoesNotPanic(t *testing.T) {
 		},
 	}
 
-	report, err := migrateGenderToSex(archive, nil)
-	require.NoError(t, err)
+	report := migrateGenderToSex(archive, nil)
 	assert.Equal(t, 0, report.PropertiesRenamed)
 }
 
@@ -150,8 +144,7 @@ func TestMigrateGenderToSex_PostSplitGenderTypesUntouched(t *testing.T) {
 		},
 	}
 
-	report, err := migrateGenderToSex(archive, &bytes.Buffer{})
-	require.NoError(t, err)
+	report := migrateGenderToSex(archive, &bytes.Buffer{})
 
 	assert.Equal(t, 0, report.VocabEntriesRenamed)
 	assert.NotNil(t, archive.GenderTypes)
@@ -166,8 +159,7 @@ func TestMigrateGenderToSex_ConflictWarnsAndLeavesGender(t *testing.T) {
 	}
 
 	warn := &bytes.Buffer{}
-	report, err := migrateGenderToSex(archive, warn)
-	require.NoError(t, err)
+	report := migrateGenderToSex(archive, warn)
 
 	assert.Equal(t, 0, report.PropertiesRenamed)
 	assert.Equal(t, "male", archive.Persons["person-1"].Properties["gender"])
@@ -182,8 +174,7 @@ func TestMigrateGenderToSex_NoOpOnAlreadyMigratedArchive(t *testing.T) {
 		},
 	}
 
-	report, err := migrateGenderToSex(archive, &bytes.Buffer{})
-	require.NoError(t, err)
+	report := migrateGenderToSex(archive, &bytes.Buffer{})
 
 	assert.Equal(t, 0, report.PropertiesRenamed)
 	assert.Equal(t, 0, report.AssertionsRenamed)

--- a/glx/migrate_gender_runner_test.go
+++ b/glx/migrate_gender_runner_test.go
@@ -18,9 +18,10 @@ import (
 	"bytes"
 	"testing"
 
-	glxlib "github.com/genealogix/glx/go-glx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	glxlib "github.com/genealogix/glx/go-glx"
 )
 
 func TestMigrateGenderToSex_PersonPropertyRename(t *testing.T) {
@@ -96,6 +97,46 @@ func TestMigrateGenderToSex_PreSplitGenderTypesMovedToSexTypes(t *testing.T) {
 	assert.Nil(t, archive.GenderTypes)
 	require.Contains(t, archive.SexTypes, "unknown")
 	assert.Equal(t, "U", archive.SexTypes["unknown"].GEDCOM)
+}
+
+func TestMigrateGenderToSex_PreSplitMergesIntoExistingSexTypes(t *testing.T) {
+	// Standard sex_types is already loaded (typical multi-file load via
+	// mergeStandardVocabularies). Custom legacy entries in gender_types should
+	// merge into sex_types without overwriting the standard ones.
+	archive := &glxlib.GLXFile{
+		SexTypes: map[string]*glxlib.SexType{
+			"male":   {Label: "Male", GEDCOM: "M"},
+			"female": {Label: "Female", GEDCOM: "F"},
+		},
+		GenderTypes: map[string]*glxlib.GenderType{
+			"male":         {Label: "OVERWRITTEN"},
+			"unknown":      {Label: "Unknown", GEDCOM: "U"},
+			"intersex":     {Label: "Intersex"},
+			"not_recorded": {Label: "Not Recorded"},
+		},
+	}
+
+	report, err := migrateGenderToSex(archive, &bytes.Buffer{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, report.VocabEntriesRenamed)
+	assert.Nil(t, archive.GenderTypes)
+	assert.Equal(t, "Male", archive.SexTypes["male"].Label, "existing sex_types entry should not be overwritten")
+	assert.Equal(t, "Unknown", archive.SexTypes["unknown"].Label)
+	assert.Equal(t, "Intersex", archive.SexTypes["intersex"].Label)
+	assert.Equal(t, "Not Recorded", archive.SexTypes["not_recorded"].Label)
+}
+
+func TestMigrateGenderToSex_NilWriterDoesNotPanic(t *testing.T) {
+	archive := &glxlib.GLXFile{
+		Persons: map[string]*glxlib.Person{
+			"person-1": {Properties: map[string]any{"gender": "male", "sex": "female"}},
+		},
+	}
+
+	report, err := migrateGenderToSex(archive, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, report.PropertiesRenamed)
 }
 
 func TestMigrateGenderToSex_PostSplitGenderTypesUntouched(t *testing.T) {

--- a/glx/migrate_gender_runner_test.go
+++ b/glx/migrate_gender_runner_test.go
@@ -151,10 +151,36 @@ func TestMigrateGenderToSex_PostSplitGenderTypesUntouched(t *testing.T) {
 	assert.Empty(t, archive.SexTypes)
 }
 
-func TestMigrateGenderToSex_ConflictWarnsAndLeavesGender(t *testing.T) {
+func TestMigrateGenderToSex_SkipsWhenSexAlreadyPresent(t *testing.T) {
+	// Any person with `sex` set signals the archive is post-split. Running the
+	// migration on such an archive must not touch `gender` (identity) values.
 	archive := &glxlib.GLXFile{
 		Persons: map[string]*glxlib.Person{
 			"person-1": {Properties: map[string]any{"gender": "male", "sex": "female"}},
+			"person-2": {Properties: map[string]any{"gender": "nonbinary"}},
+		},
+	}
+
+	warn := &bytes.Buffer{}
+	report := migrateGenderToSex(archive, warn)
+
+	assert.Equal(t, 0, report.PropertiesRenamed)
+	assert.Equal(t, 0, report.AssertionsRenamed)
+	assert.Equal(t, 0, report.VocabEntriesRenamed)
+	assert.Equal(t, "male", archive.Persons["person-1"].Properties["gender"])
+	assert.Equal(t, "female", archive.Persons["person-1"].Properties["sex"])
+	assert.Equal(t, "nonbinary", archive.Persons["person-2"].Properties["gender"])
+	assert.Contains(t, warn.String(), "post-split")
+}
+
+func TestMigrateGenderToSex_SkipsWhenGenderHasNonbinary(t *testing.T) {
+	// `nonbinary` only appears in the post-split gender_types vocabulary, so
+	// its presence (even without any `sex` values) signals the archive is
+	// using `gender` as identity.
+	archive := &glxlib.GLXFile{
+		Persons: map[string]*glxlib.Person{
+			"person-1": {Properties: map[string]any{"gender": "male"}},
+			"person-2": {Properties: map[string]any{"gender": "nonbinary"}},
 		},
 	}
 
@@ -163,8 +189,26 @@ func TestMigrateGenderToSex_ConflictWarnsAndLeavesGender(t *testing.T) {
 
 	assert.Equal(t, 0, report.PropertiesRenamed)
 	assert.Equal(t, "male", archive.Persons["person-1"].Properties["gender"])
-	assert.Equal(t, "female", archive.Persons["person-1"].Properties["sex"])
-	assert.Contains(t, warn.String(), "person-1")
+	assert.NotContains(t, archive.Persons["person-1"].Properties, "sex")
+	assert.Contains(t, warn.String(), "post-split")
+}
+
+func TestMigrateGenderToSex_SkipsWhenAssertionTargetsSex(t *testing.T) {
+	archive := &glxlib.GLXFile{
+		Persons: map[string]*glxlib.Person{
+			"person-1": {Properties: map[string]any{"gender": "male"}},
+		},
+		Assertions: map[string]*glxlib.Assertion{
+			"a-1": {Subject: glxlib.EntityRef{Person: "person-1"}, Property: "sex", Value: "male"},
+		},
+	}
+
+	warn := &bytes.Buffer{}
+	report := migrateGenderToSex(archive, warn)
+
+	assert.Equal(t, 0, report.PropertiesRenamed)
+	assert.Equal(t, 0, report.AssertionsRenamed)
+	assert.Contains(t, warn.String(), "post-split")
 }
 
 func TestMigrateGenderToSex_NoOpOnAlreadyMigratedArchive(t *testing.T) {

--- a/glx/migrate_gender_runner_test.go
+++ b/glx/migrate_gender_runner_test.go
@@ -1,0 +1,150 @@
+// Copyright 2025 Oracynth, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	glxlib "github.com/genealogix/glx/go-glx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrateGenderToSex_PersonPropertyRename(t *testing.T) {
+	archive := &glxlib.GLXFile{
+		Persons: map[string]*glxlib.Person{
+			"person-1": {Properties: map[string]any{"gender": "male"}},
+			"person-2": {Properties: map[string]any{"gender": "female", "occupation": "teacher"}},
+		},
+	}
+
+	report, err := migrateGenderToSex(archive, &bytes.Buffer{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, report.PropertiesRenamed)
+	assert.Equal(t, "male", archive.Persons["person-1"].Properties["sex"])
+	assert.NotContains(t, archive.Persons["person-1"].Properties, "gender")
+	assert.Equal(t, "female", archive.Persons["person-2"].Properties["sex"])
+	assert.Equal(t, "teacher", archive.Persons["person-2"].Properties["occupation"])
+}
+
+func TestMigrateGenderToSex_AssertionRename(t *testing.T) {
+	archive := &glxlib.GLXFile{
+		Persons: map[string]*glxlib.Person{
+			"person-1": {Properties: map[string]any{"gender": "male"}},
+		},
+		Assertions: map[string]*glxlib.Assertion{
+			"a-1": {Subject: glxlib.EntityRef{Person: "person-1"}, Property: "gender", Value: "male"},
+			"a-2": {Subject: glxlib.EntityRef{Person: "person-1"}, Property: "occupation", Value: "farmer"},
+		},
+	}
+
+	report, err := migrateGenderToSex(archive, &bytes.Buffer{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, report.AssertionsRenamed)
+	assert.Equal(t, "sex", archive.Assertions["a-1"].Property)
+	assert.Equal(t, "occupation", archive.Assertions["a-2"].Property)
+}
+
+func TestMigrateGenderToSex_VocabEntryRename(t *testing.T) {
+	archive := &glxlib.GLXFile{
+		PersonProperties: map[string]*glxlib.PropertyDefinition{
+			"gender": {
+				Label:          "Gender",
+				VocabularyType: glxlib.VocabGenderTypes,
+			},
+		},
+	}
+
+	report, err := migrateGenderToSex(archive, &bytes.Buffer{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, report.VocabEntriesRenamed)
+	require.Contains(t, archive.PersonProperties, "sex")
+	assert.NotContains(t, archive.PersonProperties, "gender")
+	assert.Equal(t, glxlib.VocabSexTypes, archive.PersonProperties["sex"].VocabularyType)
+}
+
+func TestMigrateGenderToSex_PreSplitGenderTypesMovedToSexTypes(t *testing.T) {
+	archive := &glxlib.GLXFile{
+		GenderTypes: map[string]*glxlib.GenderType{
+			"male":    {Label: "Male", GEDCOM: "M"},
+			"female":  {Label: "Female", GEDCOM: "F"},
+			"unknown": {Label: "Unknown", GEDCOM: "U"},
+			"other":   {Label: "Other", GEDCOM: "X"},
+		},
+	}
+
+	report, err := migrateGenderToSex(archive, &bytes.Buffer{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, report.VocabEntriesRenamed)
+	assert.Nil(t, archive.GenderTypes)
+	require.Contains(t, archive.SexTypes, "unknown")
+	assert.Equal(t, "U", archive.SexTypes["unknown"].GEDCOM)
+}
+
+func TestMigrateGenderToSex_PostSplitGenderTypesUntouched(t *testing.T) {
+	// Vocabulary contains "nonbinary" -> already the new identity vocabulary.
+	archive := &glxlib.GLXFile{
+		GenderTypes: map[string]*glxlib.GenderType{
+			"male":      {Label: "Male"},
+			"female":    {Label: "Female"},
+			"nonbinary": {Label: "Non-binary"},
+			"other":     {Label: "Other"},
+		},
+	}
+
+	report, err := migrateGenderToSex(archive, &bytes.Buffer{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, report.VocabEntriesRenamed)
+	assert.NotNil(t, archive.GenderTypes)
+	assert.Empty(t, archive.SexTypes)
+}
+
+func TestMigrateGenderToSex_ConflictWarnsAndLeavesGender(t *testing.T) {
+	archive := &glxlib.GLXFile{
+		Persons: map[string]*glxlib.Person{
+			"person-1": {Properties: map[string]any{"gender": "male", "sex": "female"}},
+		},
+	}
+
+	warn := &bytes.Buffer{}
+	report, err := migrateGenderToSex(archive, warn)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, report.PropertiesRenamed)
+	assert.Equal(t, "male", archive.Persons["person-1"].Properties["gender"])
+	assert.Equal(t, "female", archive.Persons["person-1"].Properties["sex"])
+	assert.Contains(t, warn.String(), "person-1")
+}
+
+func TestMigrateGenderToSex_NoOpOnAlreadyMigratedArchive(t *testing.T) {
+	archive := &glxlib.GLXFile{
+		Persons: map[string]*glxlib.Person{
+			"person-1": {Properties: map[string]any{"sex": "male"}},
+		},
+	}
+
+	report, err := migrateGenderToSex(archive, &bytes.Buffer{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, report.PropertiesRenamed)
+	assert.Equal(t, 0, report.AssertionsRenamed)
+	assert.Equal(t, 0, report.VocabEntriesRenamed)
+}

--- a/glx/migrate_gender_runner_test.go
+++ b/glx/migrate_gender_runner_test.go
@@ -49,6 +49,9 @@ func TestMigrateGenderToSex_AssertionRename(t *testing.T) {
 		Assertions: map[string]*glxlib.Assertion{
 			"a-1": {Subject: glxlib.EntityRef{Person: "person-1"}, Property: "gender", Value: "male"},
 			"a-2": {Subject: glxlib.EntityRef{Person: "person-1"}, Property: "occupation", Value: "farmer"},
+			// Non-person subject — a custom "gender" property on an event
+			// must NOT be renamed by this migration.
+			"a-3": {Subject: glxlib.EntityRef{Event: "event-1"}, Property: "gender", Value: "mixed"},
 		},
 	}
 
@@ -57,6 +60,7 @@ func TestMigrateGenderToSex_AssertionRename(t *testing.T) {
 	assert.Equal(t, 1, report.AssertionsRenamed)
 	assert.Equal(t, "sex", archive.Assertions["a-1"].Property)
 	assert.Equal(t, "occupation", archive.Assertions["a-2"].Property)
+	assert.Equal(t, "gender", archive.Assertions["a-3"].Property)
 }
 
 func TestMigrateGenderToSex_VocabEntryRename(t *testing.T) {

--- a/glx/migrate_runner.go
+++ b/glx/migrate_runner.go
@@ -28,6 +28,11 @@ type MigrateReport struct {
 	PropertiesRemoved   int
 	AssertionsMigrated  int
 	VocabEntriesRemoved int
+
+	// gender→sex rename counts (opt-in via --rename-gender-to-sex).
+	PropertiesRenamed   int
+	AssertionsRenamed   int
+	VocabEntriesRenamed int
 }
 
 const (

--- a/glx/query_runner.go
+++ b/glx/query_runner.go
@@ -614,14 +614,14 @@ func propertyString(props map[string]any, key string) string {
 	return fmt.Sprint(raw)
 }
 
-// personSex returns the person's recorded sex, falling back to the legacy
-// gender property for archives created before the two-field-model split (#528).
+// personSex returns the person's recorded sex. It intentionally does not
+// fall back to the gender property: post-split (#528), `gender` represents
+// self-identified gender identity, and leaking identity values (e.g.,
+// `nonbinary`) into sex-based inferences (parent role labelling, vitals)
+// is incorrect. Legacy archives should run `glx migrate --rename-gender-to-sex`
+// before using these CLI commands.
 func personSex(person *glxlib.Person) string {
-	if v := propertyString(person.Properties, glxlib.PersonPropertySex); v != "" {
-		return v
-	}
-
-	return propertyString(person.Properties, glxlib.PersonPropertyGender)
+	return propertyString(person.Properties, glxlib.PersonPropertySex)
 }
 
 // queryDayMonthRegexp matches day-of-month followed by a month abbreviation

--- a/glx/query_runner.go
+++ b/glx/query_runner.go
@@ -614,6 +614,15 @@ func propertyString(props map[string]any, key string) string {
 	return fmt.Sprint(raw)
 }
 
+// personSex returns the person's recorded sex, falling back to the legacy
+// gender property for archives created before the two-field-model split (#528).
+func personSex(person *glxlib.Person) string {
+	if v := propertyString(person.Properties, glxlib.PersonPropertySex); v != "" {
+		return v
+	}
+	return propertyString(person.Properties, glxlib.PersonPropertyGender)
+}
+
 // queryDayMonthRegexp matches day-of-month followed by a month abbreviation
 // (e.g., "15 MAR"). Used to strip day values before year extraction so that
 // 1–2 digit days are not mistaken for 1–2 digit years.

--- a/glx/query_runner.go
+++ b/glx/query_runner.go
@@ -620,6 +620,7 @@ func personSex(person *glxlib.Person) string {
 	if v := propertyString(person.Properties, glxlib.PersonPropertySex); v != "" {
 		return v
 	}
+
 	return propertyString(person.Properties, glxlib.PersonPropertyGender)
 }
 

--- a/glx/query_runner.go
+++ b/glx/query_runner.go
@@ -614,14 +614,40 @@ func propertyString(props map[string]any, key string) string {
 	return fmt.Sprint(raw)
 }
 
-// personSex returns the person's recorded sex. It intentionally does not
-// fall back to the gender property: post-split (#528), `gender` represents
-// self-identified gender identity, and leaking identity values (e.g.,
-// `nonbinary`) into sex-based inferences (parent role labeling, vitals)
-// is incorrect. Legacy archives should run `glx migrate --rename-gender-to-sex`
-// before using these CLI commands.
+// personSex returns the person's recorded sex, with a safe back-compat
+// fallback to `gender` for pre-#528 archives.
+//
+// Fallback rules: if `sex` is empty and `gender` holds a value that exists
+// in the sex vocabulary (male, female, unknown, other, not_recorded), the
+// gender value is used. Identity-only values (notably `nonbinary`) are
+// never surfaced as Sex — they can't have come from a legacy archive and
+// belong to the post-split `gender` (identity) semantics.
+//
+// Operators on pre-split archives can run `glx migrate --rename-gender-to-sex`
+// to make the data explicit.
 func personSex(person *glxlib.Person) string {
-	return propertyString(person.Properties, glxlib.PersonPropertySex)
+	if v := propertyString(person.Properties, glxlib.PersonPropertySex); v != "" {
+		return v
+	}
+	legacy := propertyString(person.Properties, glxlib.PersonPropertyGender)
+	if isLegacySexValue(legacy) {
+		return legacy
+	}
+
+	return ""
+}
+
+// isLegacySexValue reports whether v could plausibly be a pre-#528 `gender`
+// property value that actually denoted recorded sex. The canonical
+// post-split identity-only value (`nonbinary`) is excluded.
+func isLegacySexValue(v string) bool {
+	switch v {
+	case glxlib.SexMale, glxlib.SexFemale, glxlib.SexUnknown,
+		glxlib.SexOther, glxlib.SexNotRecorded:
+		return true
+	}
+
+	return false
 }
 
 // queryDayMonthRegexp matches day-of-month followed by a month abbreviation

--- a/glx/query_runner.go
+++ b/glx/query_runner.go
@@ -617,7 +617,7 @@ func propertyString(props map[string]any, key string) string {
 // personSex returns the person's recorded sex. It intentionally does not
 // fall back to the gender property: post-split (#528), `gender` represents
 // self-identified gender identity, and leaking identity values (e.g.,
-// `nonbinary`) into sex-based inferences (parent role labelling, vitals)
+// `nonbinary`) into sex-based inferences (parent role labeling, vitals)
 // is incorrect. Legacy archives should run `glx migrate --rename-gender-to-sex`
 // before using these CLI commands.
 func personSex(person *glxlib.Person) string {

--- a/glx/query_runner_test.go
+++ b/glx/query_runner_test.go
@@ -411,7 +411,7 @@ func TestExtractAllNames_TemporalList(t *testing.T) {
 }
 
 func TestExtractAllNames_NoName(t *testing.T) {
-	person := &glxlib.Person{Properties: map[string]any{"gender": "male"}}
+	person := &glxlib.Person{Properties: map[string]any{"sex": "male"}}
 	names := extractAllNames(person)
 	assert.Nil(t, names)
 }
@@ -458,7 +458,7 @@ func TestExtractPersonName(t *testing.T) {
 		},
 		{
 			name:  "no name property",
-			props: map[string]any{"gender": "male"},
+			props: map[string]any{"sex": "male"},
 			want:  "(unnamed)",
 		},
 	}

--- a/glx/summary_runner.go
+++ b/glx/summary_runner.go
@@ -270,11 +270,7 @@ func printIdentitySection(person *glxlib.Person) {
 	name := extractPersonName(person)
 	fmt.Printf("  %-18s%s\n", "Name:", name)
 
-	gender := propertyString(person.Properties, "gender")
-	if gender == "" {
-		gender = propertyString(person.Properties, "sex")
-	}
-	fmt.Printf("  %-18s%s\n", "Sex:", displayOrDash(gender))
+	fmt.Printf("  %-18s%s\n", "Sex:", displayOrDash(personSex(person)))
 
 	variants := extractAllNameVariants(person)
 	if len(variants) > 1 {
@@ -476,10 +472,10 @@ func printFamilySection(personID string, archive *glxlib.GLXFile) {
 			name := pid
 			if ok {
 				name = extractPersonName(parent)
-				gender := strings.ToLower(propertyString(parent.Properties, "gender"))
-				if gender == "male" {
+				switch strings.ToLower(personSex(parent)) {
+				case "male":
 					label = "Father"
-				} else if gender == "female" {
+				case "female":
 					label = "Mother"
 				}
 			}
@@ -1090,11 +1086,11 @@ func narrativeDate(date string) string {
 }
 
 // pronounFor returns subject ("He"/"She"/"They") and possessive ("his"/"her"/"their")
-// pronouns based on the person's gender property.
+// pronouns. Prefers gender identity when set; otherwise falls back to recorded sex.
 func pronounFor(person *glxlib.Person) (subject, possessive string) {
-	gender := strings.ToLower(propertyString(person.Properties, "gender"))
+	gender := strings.ToLower(propertyString(person.Properties, glxlib.PersonPropertyGender))
 	if gender == "" {
-		gender = strings.ToLower(propertyString(person.Properties, "sex"))
+		gender = strings.ToLower(propertyString(person.Properties, glxlib.PersonPropertySex))
 	}
 
 	switch gender {

--- a/glx/summary_runner.go
+++ b/glx/summary_runner.go
@@ -473,9 +473,9 @@ func printFamilySection(personID string, archive *glxlib.GLXFile) {
 			if ok {
 				name = extractPersonName(parent)
 				switch strings.ToLower(personSex(parent)) {
-				case "male":
+				case glxlib.SexMale:
 					label = "Father"
-				case "female":
+				case glxlib.SexFemale:
 					label = "Mother"
 				}
 			}
@@ -1094,9 +1094,9 @@ func pronounFor(person *glxlib.Person) (subject, possessive string) {
 	}
 
 	switch gender {
-	case "male":
+	case glxlib.GenderMale:
 		return "He", "his"
-	case "female":
+	case glxlib.GenderFemale:
 		return "She", "her"
 	default:
 		return "They", "their"

--- a/glx/summary_runner_test.go
+++ b/glx/summary_runner_test.go
@@ -40,7 +40,7 @@ func newTestArchive() *glxlib.GLXFile {
 							"fields": map[string]any{"type": "nickname"},
 						},
 					},
-					"gender": "male",
+					"sex": "male",
 				},
 			},
 			"person-jane": {
@@ -55,19 +55,19 @@ func newTestArchive() *glxlib.GLXFile {
 							"fields": map[string]any{"type": "married"},
 						},
 					},
-					"gender": "female",
+					"sex": "female",
 				},
 			},
 			"person-child": {
 				Properties: map[string]any{
 					"name":   "Alice Smith",
-					"gender": "female",
+					"sex": "female",
 				},
 			},
 			"person-child2": {
 				Properties: map[string]any{
 					"name":   "Bob Smith",
-					"gender": "male",
+					"sex": "male",
 				},
 			},
 			"person-neighbor": {
@@ -252,7 +252,7 @@ func TestExtractAllNameVariants_StructuredMap(t *testing.T) {
 
 func TestExtractAllNameVariants_NoName(t *testing.T) {
 	person := &glxlib.Person{
-		Properties: map[string]any{"gender": "male"},
+		Properties: map[string]any{"sex": "male"},
 	}
 
 	variants := extractAllNameVariants(person)
@@ -400,9 +400,9 @@ func TestDisplayDate(t *testing.T) {
 func TestFindSpouses_ChronologicalOrder(t *testing.T) {
 	archive := &glxlib.GLXFile{
 		Persons: map[string]*glxlib.Person{
-			"person-mary": {Properties: map[string]any{"name": "Mary Green", "gender": "female"}},
-			"person-dan":  {Properties: map[string]any{"name": "Daniel Lane", "gender": "male"}},
-			"person-john": {Properties: map[string]any{"name": "John Babcock", "gender": "male"}},
+			"person-mary": {Properties: map[string]any{"name": "Mary Green", "sex": "female"}},
+			"person-dan":  {Properties: map[string]any{"name": "Daniel Lane", "sex": "male"}},
+			"person-john": {Properties: map[string]any{"name": "John Babcock", "sex": "male"}},
 		},
 		Relationships: map[string]*glxlib.Relationship{
 			"rel-marriage-babcock": {
@@ -452,9 +452,9 @@ func TestFindSpouses_ChronologicalOrder(t *testing.T) {
 func TestFindSpouses_SameYearDifferentMonths(t *testing.T) {
 	archive := &glxlib.GLXFile{
 		Persons: map[string]*glxlib.Person{
-			"person-mary": {Properties: map[string]any{"name": "Mary", "gender": "female"}},
-			"person-a":    {Properties: map[string]any{"name": "Spouse A", "gender": "male"}},
-			"person-b":    {Properties: map[string]any{"name": "Spouse B", "gender": "male"}},
+			"person-mary": {Properties: map[string]any{"name": "Mary", "sex": "female"}},
+			"person-a":    {Properties: map[string]any{"name": "Spouse A", "sex": "male"}},
+			"person-b":    {Properties: map[string]any{"name": "Spouse B", "sex": "male"}},
 		},
 		Relationships: map[string]*glxlib.Relationship{
 			"rel-b": {
@@ -505,9 +505,9 @@ func TestFindSpouses_SameYearDifferentMonths(t *testing.T) {
 func TestFindSpouses_UndatedLast(t *testing.T) {
 	archive := &glxlib.GLXFile{
 		Persons: map[string]*glxlib.Person{
-			"person-mary": {Properties: map[string]any{"name": "Mary", "gender": "female"}},
-			"person-a":    {Properties: map[string]any{"name": "Spouse A", "gender": "male"}},
-			"person-b":    {Properties: map[string]any{"name": "Spouse B", "gender": "male"}},
+			"person-mary": {Properties: map[string]any{"name": "Mary", "sex": "female"}},
+			"person-a":    {Properties: map[string]any{"name": "Spouse A", "sex": "male"}},
+			"person-b":    {Properties: map[string]any{"name": "Spouse B", "sex": "male"}},
 		},
 		Relationships: map[string]*glxlib.Relationship{
 			"rel-a": {
@@ -547,8 +547,8 @@ func TestFindSpouses_UndatedLast(t *testing.T) {
 }
 
 func TestPronounFor(t *testing.T) {
-	male := &glxlib.Person{Properties: map[string]any{"gender": "male"}}
-	female := &glxlib.Person{Properties: map[string]any{"gender": "female"}}
+	male := &glxlib.Person{Properties: map[string]any{"sex": "male"}}
+	female := &glxlib.Person{Properties: map[string]any{"sex": "female"}}
 	unknown := &glxlib.Person{Properties: map[string]any{}}
 
 	subj, poss := pronounFor(male)
@@ -584,7 +584,7 @@ func TestGenerateLifeHistory(t *testing.T) {
 func TestGenerateLifeHistory_IncludesChildren(t *testing.T) {
 	archive := &glxlib.GLXFile{
 		Persons: map[string]*glxlib.Person{
-			"person-jane":     {Properties: map[string]any{"name": "Jane Miller", "gender": "female"}},
+			"person-jane":     {Properties: map[string]any{"name": "Jane Miller", "sex": "female"}},
 			"person-harriett": {Properties: map[string]any{"name": "Harriett Webb"}},
 			"person-elijah":   {Properties: map[string]any{"name": "Elijah Webb"}},
 			"person-mary":     {Properties: map[string]any{"name": "Mary Ellen Webb"}},

--- a/glx/testdata/invalid/broken-references/persons/person-jane-smith.glx
+++ b/glx/testdata/invalid/broken-references/persons/person-jane-smith.glx
@@ -6,7 +6,7 @@ persons:
         fields:
           given: "Jane"
           surname: "Smith"
-      gender: "female"
+      sex: "female"
     notes: "Daughter of John Smith and Mary Brown."
     tags:
       - "descendant"

--- a/glx/testdata/invalid/broken-references/persons/person-john-smith.glx
+++ b/glx/testdata/invalid/broken-references/persons/person-john-smith.glx
@@ -6,7 +6,7 @@ persons:
         fields:
           given: "John"
           surname: "Smith"
-      gender: "male"
+      sex: "male"
     notes: "Blacksmith in Leeds, Yorkshire. Married Mary Brown in 1875."
     tags:
       - "ancestor"

--- a/glx/testdata/invalid/broken-references/persons/person-mary-brown.glx
+++ b/glx/testdata/invalid/broken-references/persons/person-mary-brown.glx
@@ -6,7 +6,7 @@ persons:
         fields:
           given: "Mary"
           surname: "Smith"
-      gender: "female"
+      sex: "female"
     notes: "Wife of John Smith. Dressmaker by trade."
     tags:
       - "ancestor"

--- a/glx/testdata/invalid/invalid-assertion-properties/persons/person-child-alice.glx
+++ b/glx/testdata/invalid/invalid-assertion-properties/persons/person-child-alice.glx
@@ -6,4 +6,4 @@ persons:
         fields:
           given: "Alice"
           surname: "Thompson"
-      gender: female
+      sex: female

--- a/glx/testdata/invalid/invalid-assertion-properties/persons/person-child-bob.glx
+++ b/glx/testdata/invalid/invalid-assertion-properties/persons/person-child-bob.glx
@@ -6,4 +6,4 @@ persons:
         fields:
           given: "Robert"
           surname: "Thompson"
-      gender: male
+      sex: male

--- a/glx/testdata/invalid/invalid-assertion-properties/persons/person-father.glx
+++ b/glx/testdata/invalid/invalid-assertion-properties/persons/person-father.glx
@@ -6,4 +6,4 @@ persons:
         fields:
           given: "Robert"
           surname: "Thompson"
-      gender: male
+      sex: male

--- a/glx/testdata/invalid/invalid-assertion-properties/persons/person-mother.glx
+++ b/glx/testdata/invalid/invalid-assertion-properties/persons/person-mother.glx
@@ -6,4 +6,4 @@ persons:
         fields:
           given: "Mary"
           surname: "Thompson"
-      gender: female
+      sex: female

--- a/glx/testdata/invalid/invalid-properties/persons/person-child-alice.glx
+++ b/glx/testdata/invalid/invalid-properties/persons/person-child-alice.glx
@@ -6,4 +6,4 @@ persons:
         fields:
           given: "Alice"
           surname: "Thompson"
-      gender: female
+      sex: female

--- a/glx/testdata/invalid/invalid-properties/persons/person-child-bob.glx
+++ b/glx/testdata/invalid/invalid-properties/persons/person-child-bob.glx
@@ -6,4 +6,4 @@ persons:
         fields:
           given: "Robert"
           surname: "Thompson"
-      gender: male
+      sex: male

--- a/glx/testdata/invalid/invalid-properties/persons/person-father.glx
+++ b/glx/testdata/invalid/invalid-properties/persons/person-father.glx
@@ -6,6 +6,6 @@ persons:
         fields:
           given: "Robert"
           surname: "Thompson"
-      gender: male
+      sex: male
       invalid_property: "should fail"
       another_invalid: "also bad"

--- a/glx/testdata/invalid/invalid-properties/persons/person-mother.glx
+++ b/glx/testdata/invalid/invalid-properties/persons/person-mother.glx
@@ -6,4 +6,4 @@ persons:
         fields:
           given: "Mary"
           surname: "Thompson"
-      gender: female
+      sex: female

--- a/glx/testdata/invalid/invalid-relationship-participants/persons/person-child-alice.glx
+++ b/glx/testdata/invalid/invalid-relationship-participants/persons/person-child-alice.glx
@@ -6,4 +6,4 @@ persons:
         fields:
           given: "Alice"
           surname: "Thompson"
-      gender: female
+      sex: female

--- a/glx/testdata/invalid/invalid-relationship-participants/persons/person-child-bob.glx
+++ b/glx/testdata/invalid/invalid-relationship-participants/persons/person-child-bob.glx
@@ -6,4 +6,4 @@ persons:
         fields:
           given: "Robert"
           surname: "Thompson"
-      gender: male
+      sex: male

--- a/glx/testdata/invalid/invalid-relationship-participants/persons/person-father.glx
+++ b/glx/testdata/invalid/invalid-relationship-participants/persons/person-father.glx
@@ -6,4 +6,4 @@ persons:
         fields:
           given: "Robert"
           surname: "Thompson"
-      gender: male
+      sex: male

--- a/glx/testdata/invalid/invalid-relationship-participants/persons/person-mother.glx
+++ b/glx/testdata/invalid/invalid-relationship-participants/persons/person-mother.glx
@@ -6,4 +6,4 @@ persons:
         fields:
           given: "Mary"
           surname: "Thompson"
-      gender: female
+      sex: female

--- a/glx/testdata/invalid/temporal-properties-malformed/archive.glx
+++ b/glx/testdata/invalid/temporal-properties-malformed/archive.glx
@@ -26,9 +26,9 @@ person_properties:
         label: "Surname"
         description: "Family name"
 
-  gender:
-    label: "Gender"
-    description: "Gender identity"
+  sex:
+    label: "Sex"
+    description: "Sex as recorded in source documents"
     value_type: string
     temporal: true
 

--- a/glx/testdata/valid/assertion-with-participant.glx
+++ b/glx/testdata/valid/assertion-with-participant.glx
@@ -9,7 +9,7 @@ persons:
         fields:
           given: "John"
           surname: "Smith"
-      gender: "male"
+      sex: "male"
 
   person-jane:
     properties:
@@ -18,7 +18,7 @@ persons:
         fields:
           given: "Jane"
           surname: "Doe"
-      gender: "female"
+      sex: "female"
 
   person-thomas:
     properties:
@@ -27,7 +27,7 @@ persons:
         fields:
           given: "Thomas"
           surname: "Brown"
-      gender: "male"
+      sex: "male"
 
 events:
   event-marriage-1880:

--- a/glx/testdata/valid/person-with-properties.glx
+++ b/glx/testdata/valid/person-with-properties.glx
@@ -25,9 +25,9 @@ person_properties:
         label: "Surname"
         description: "Family name"
 
-  gender:
-    label: "Gender"
-    description: "Gender identity"
+  sex:
+    label: "Sex"
+    description: "Sex as recorded in source documents"
     value_type: string
 
   occupation:
@@ -51,7 +51,7 @@ persons:
         fields:
           given: "John"
           surname: "Smith"
-      gender: "male"
+      sex: "male"
       occupation:
         - value: "blacksmith"
           date: "1870"
@@ -74,7 +74,7 @@ persons:
         fields:
           given: "Jane"
           surname: "Doe"
-      gender: "female"
+      sex: "female"
     notes: "Additional research needed"
 
 # Life events for persons

--- a/glx/testdata/valid/temporal-properties-simple/archive.glx
+++ b/glx/testdata/valid/temporal-properties-simple/archive.glx
@@ -30,9 +30,9 @@ person_properties:
         label: "Surname"
         description: "Family name"
 
-  gender:
-    label: "Gender"
-    description: "Gender identity"
+  sex:
+    label: "Sex"
+    description: "Sex as recorded in source documents"
     value_type: string
     temporal: false  # Non-temporal property
 
@@ -57,6 +57,6 @@ persons:
         fields:
           given: "John"
           surname: "Smith"
-      gender: "male"                # Simple value for non-temporal - VALID
+      sex: "male"                # Simple value for non-temporal - VALID
       occupation: "blacksmith"     # Simple string for temporal property - VALID
       residence: "place-leeds"     # Simple reference for temporal property - VALID

--- a/glx/vitals_runner.go
+++ b/glx/vitals_runner.go
@@ -122,12 +122,7 @@ func collectVitals(personID string, person *glxlib.Person, archive *glxlib.GLXFi
 	name := extractPersonName(person)
 	vitals = append(vitals, vitalRecord{"Name", name})
 
-	// Sex/Gender
-	gender := propertyString(person.Properties, "gender")
-	if gender == "" {
-		gender = propertyString(person.Properties, "sex")
-	}
-	vitals = append(vitals, vitalRecord{"Sex", displayOrDash(gender)})
+	vitals = append(vitals, vitalRecord{"Sex", displayOrDash(personSex(person))})
 
 	// Birth — from events
 	birth := findEventByType(personID, "birth", eventIDs, archive)

--- a/glx/vitals_runner_test.go
+++ b/glx/vitals_runner_test.go
@@ -142,7 +142,7 @@ func TestCollectVitals(t *testing.T) {
 					"name": map[string]any{
 						"value": "John Smith",
 					},
-					"gender": "male",
+					"sex": "male",
 				},
 			},
 		},
@@ -211,7 +211,7 @@ func TestCollectVitals_WitnessChristeningExcluded(t *testing.T) {
 		Persons: map[string]*glxlib.Person{
 			"person-grandfather": {Properties: map[string]any{
 				"name":   "Martin Krause",
-				"gender": "male",
+				"sex": "male",
 			}},
 			"person-grandchild": {Properties: map[string]any{
 				"name": "Christine Krause",

--- a/go-glx/census.go
+++ b/go-glx/census.go
@@ -417,7 +417,7 @@ func resolveCensusPerson(member CensusHouseholdMember, existing *GLXFile, result
 		},
 	}
 	if member.Sex != "" {
-		person.Properties[PersonPropertyGender] = strings.ToLower(member.Sex)
+		person.Properties[PersonPropertySex] = strings.ToLower(member.Sex)
 	}
 
 	result.Persons[personID] = person
@@ -526,12 +526,12 @@ func generateCensusAssertions(census *CensusData, resolvedIDs []string, placeID,
 			}
 		}
 
-		// Gender
+		// Sex (as recorded in the census)
 		if member.Sex != "" {
-			assertionID := uniqueAssertionID(fmt.Sprintf("assertion-%s-gender-%s", pidSlug, yearStr), existing, result)
+			assertionID := uniqueAssertionID(fmt.Sprintf("assertion-%s-sex-%s", pidSlug, yearStr), existing, result)
 			result.Assertions[assertionID] = &Assertion{
 				Subject:    EntityRef{Person: personID},
-				Property:   PersonPropertyGender,
+				Property:   PersonPropertySex,
 				Value:      strings.ToLower(member.Sex),
 				Citations:  []string{citationID},
 				Confidence: ConfidenceLevelHigh,

--- a/go-glx/census_test.go
+++ b/go-glx/census_test.go
@@ -53,7 +53,7 @@ func TestBuildCensusEntities_Minimal(t *testing.T) {
 	person := result.Persons[result.NewPersonIDs[0]]
 	require.NotNil(t, person)
 	assert.Equal(t, "Daniel Lane", person.Properties[PersonPropertyName])
-	assert.Equal(t, "male", person.Properties[PersonPropertyGender])
+	assert.Equal(t, "male", person.Properties[PersonPropertySex])
 
 	// Check event
 	event := result.Event[result.EventID]
@@ -363,12 +363,12 @@ func TestBuildCensusEntities_Assertions(t *testing.T) {
 	assert.Equal(t, ConfidenceLevelLow, birthAssertion.Confidence)
 	assert.Contains(t, birthAssertion.Notes.String(), "age 30")
 
-	// Check gender assertion
-	genderAssertion := result.Assertions["assertion-person-daniel-lane-gender-1860"]
-	require.NotNil(t, genderAssertion, "should have gender assertion")
-	assert.Equal(t, PersonPropertyGender, genderAssertion.Property)
-	assert.Equal(t, "male", genderAssertion.Value)
-	assert.Equal(t, ConfidenceLevelHigh, genderAssertion.Confidence)
+	// Check sex assertion
+	sexAssertion := result.Assertions["assertion-person-daniel-lane-sex-1860"]
+	require.NotNil(t, sexAssertion, "should have sex assertion")
+	assert.Equal(t, PersonPropertySex, sexAssertion.Property)
+	assert.Equal(t, "male", sexAssertion.Value)
+	assert.Equal(t, ConfidenceLevelHigh, sexAssertion.Confidence)
 
 	// Check occupation assertion
 	occAssertion := result.Assertions["assertion-person-daniel-lane-occupation-1860"]

--- a/go-glx/constants.go
+++ b/go-glx/constants.go
@@ -99,7 +99,8 @@ const (
 // Standard Person Property Names - commonly used properties on Person entities
 const (
 	PersonPropertyName       = "name"
-	PersonPropertyGender     = "gender"
+	PersonPropertySex        = "sex"    // Sex as recorded in source documents; maps to GEDCOM SEX
+	PersonPropertyGender     = "gender" // Self-identified gender identity; no direct GEDCOM mapping
 	PersonPropertyResidence  = "residence"
 	PersonPropertyOccupation = "occupation"
 )
@@ -416,6 +417,7 @@ const (
 	VocabMediaTypes        = "media_types"
 	VocabConfidenceLevels  = "confidence_levels"
 	VocabSourceTypes       = "source_types"
+	VocabSexTypes          = "sex_types"
 	VocabGenderTypes       = "gender_types"
 )
 
@@ -582,14 +584,24 @@ const (
 	GEDCOMVersion70  = "7.0"
 )
 
-// Gender values for GEDCOM import/export mapping.
+// Sex values for GEDCOM import/export mapping.
 // GEDCOM SEX tag: M→male, F→female, U→unknown, X→other.
-// Gender is vocabulary-constrained via vocabulary_type: gender_types.
+// Sex is vocabulary-constrained via vocabulary_type: sex_types.
 const (
-	GenderMale    = "male"
-	GenderFemale  = "female"
-	GenderUnknown = "unknown"
-	GenderOther   = "other"
+	SexMale        = "male"
+	SexFemale      = "female"
+	SexUnknown     = "unknown"
+	SexNotRecorded = "not_recorded"
+	SexOther       = "other"
+)
+
+// Gender identity values. Vocabulary-constrained via vocabulary_type: gender_types.
+// No direct GEDCOM mapping (GEDCOM defers identity to FACT).
+const (
+	GenderMale      = "male"
+	GenderFemale    = "female"
+	GenderNonbinary = "nonbinary"
+	GenderOther     = "other"
 )
 
 // File Extensions

--- a/go-glx/gedcom_comprehensive_test.go
+++ b/go-glx/gedcom_comprehensive_test.go
@@ -201,12 +201,12 @@ func TestGEDCOM555_Sample_DataPersistence(t *testing.T) {
 		if givenName == "Robert Eugene" && familyName == "Williams" {
 			foundRobert = true
 
-			// Verify gender persisted
-			if gender, ok := person.Properties[PersonPropertyGender].(string); !ok || gender != GenderMale {
-				t.Error("Robert Eugene Williams should have gender 'male'")
+			// Verify recorded sex persisted
+			if sex, ok := person.Properties[PersonPropertySex].(string); !ok || sex != SexMale {
+				t.Error("Robert Eugene Williams should have sex 'male'")
 			}
 
-			t.Logf("✓ Robert Eugene Williams: name and gender persisted correctly")
+			t.Logf("✓ Robert Eugene Williams: name and sex persisted correctly")
 
 			break
 		}
@@ -223,12 +223,12 @@ func TestGEDCOM555_Sample_DataPersistence(t *testing.T) {
 		if givenName == "Mary Ann" && familyName == "Wilson" {
 			foundMary = true
 
-			// Verify gender persisted
-			if gender, ok := person.Properties[PersonPropertyGender].(string); !ok || gender != "female" {
-				t.Error("Mary Ann Wilson should have gender 'female'")
+			// Verify recorded sex persisted
+			if sex, ok := person.Properties[PersonPropertySex].(string); !ok || sex != "female" {
+				t.Error("Mary Ann Wilson should have sex 'female'")
 			}
 
-			t.Logf("✓ Mary Ann Wilson: name and gender persisted correctly")
+			t.Logf("✓ Mary Ann Wilson: name and sex persisted correctly")
 
 			break
 		}

--- a/go-glx/gedcom_e2e_test.go
+++ b/go-glx/gedcom_e2e_test.go
@@ -72,7 +72,7 @@ func TestE2E_GEDCOM551_Shakespeare(t *testing.T) {
 		given, family := ExtractNameFields(person.Properties[PersonPropertyName])
 		if given == "William" && family == "Shakespeare" {
 			foundWilliam = true
-			if gender, ok := person.Properties[PersonPropertyGender].(string); !ok || gender != "male" {
+			if sex, ok := person.Properties[PersonPropertySex].(string); !ok || sex != "male" {
 				t.Error("William Shakespeare should be male")
 			}
 		}

--- a/go-glx/gedcom_export_family.go
+++ b/go-glx/gedcom_export_family.go
@@ -65,14 +65,14 @@ func reconstructFamilies(expCtx *ExportContext) {
 			continue
 		}
 
-		// Determine HUSB/WIFE by gender
+		// Determine HUSB/WIFE by recorded sex
 		var husbandID, wifeID string
 		if len(spouseIDs) >= 2 {
 			husbandID, wifeID = assignHusbandWife(spouseIDs[0], spouseIDs[1], expCtx)
 		} else {
-			// Single-spouse marriage — assign by gender
-			gender := getPersonGender(spouseIDs[0], expCtx)
-			if gender == GenderFemale {
+			// Single-spouse marriage — assign by recorded sex
+			sex := getPersonSex(spouseIDs[0], expCtx)
+			if sex == SexFemale {
 				wifeID = spouseIDs[0]
 			} else {
 				husbandID = spouseIDs[0]
@@ -513,36 +513,38 @@ func extractSpouseIDs(rel *Relationship) []string {
 	return spouseIDs
 }
 
-// assignHusbandWife determines HUSB/WIFE assignment based on gender.
+// assignHusbandWife determines HUSB/WIFE assignment based on recorded sex.
 // Male -> HUSB, Female -> WIFE. If both same or unknown, first -> HUSB, second -> WIFE.
 func assignHusbandWife(personA, personB string, expCtx *ExportContext) (husbandID, wifeID string) {
-	genderA := getPersonGender(personA, expCtx)
-	genderB := getPersonGender(personB, expCtx)
+	sexA := getPersonSex(personA, expCtx)
+	sexB := getPersonSex(personB, expCtx)
 
 	switch {
-	case genderA == GenderMale && genderB == GenderFemale:
+	case sexA == SexMale && sexB == SexFemale:
 		return personA, personB
-	case genderA == GenderFemale && genderB == GenderMale:
+	case sexA == SexFemale && sexB == SexMale:
 		return personB, personA
 	default:
-		// Same gender, both unknown, or mixed unknown — first is HUSB, second is WIFE
+		// Same sex, both unknown, or mixed unknown — first is HUSB, second is WIFE
 		return personA, personB
 	}
 }
 
-// getPersonGender retrieves the gender property for a person ID.
-func getPersonGender(personID string, expCtx *ExportContext) string {
+// getPersonSex retrieves the recorded sex property for a person ID, falling
+// back to the legacy gender property.
+func getPersonSex(personID string, expCtx *ExportContext) string {
 	person, ok := expCtx.GLX.Persons[personID]
 	if !ok {
 		return ""
 	}
 
-	gender, ok := getStringProperty(person.Properties, PersonPropertyGender)
-	if !ok {
-		return ""
+	if sex, ok := getStringProperty(person.Properties, PersonPropertySex); ok {
+		return sex
 	}
-
-	return gender
+	if gender, ok := getStringProperty(person.Properties, PersonPropertyGender); ok {
+		return gender
+	}
+	return ""
 }
 
 // relationshipTypeToPedi maps GLX relationship types to GEDCOM PEDI values.
@@ -587,13 +589,13 @@ func extractParentChildIDs(rel *Relationship) (parentID, childID string) {
 
 // createSyntheticFamily creates a single-parent FAM for a parent without a marriage.
 func createSyntheticFamily(parentID string, expCtx *ExportContext, parentToFamilies map[string][]int) int {
-	gender := getPersonGender(parentID, expCtx)
+	sex := getPersonSex(parentID, expCtx)
 
 	family := &ExportFamily{
 		ChildPedigrees: make(map[string]string),
 	}
 
-	if gender == GenderFemale {
+	if sex == SexFemale {
 		family.WifeID = parentID
 	} else {
 		family.HusbandID = parentID

--- a/go-glx/gedcom_export_family.go
+++ b/go-glx/gedcom_export_family.go
@@ -544,6 +544,7 @@ func getPersonSex(personID string, expCtx *ExportContext) string {
 	if gender, ok := getStringProperty(person.Properties, PersonPropertyGender); ok {
 		return gender
 	}
+
 	return ""
 }
 

--- a/go-glx/gedcom_export_family_test.go
+++ b/go-glx/gedcom_export_family_test.go
@@ -32,12 +32,12 @@ func TestReconstructFamilies_BasicMarriage(t *testing.T) {
 			Persons: map[string]*Person{
 				"person-husband": {
 					Properties: map[string]any{
-						PersonPropertyGender: "male",
+						PersonPropertySex: "male",
 					},
 				},
 				"person-wife": {
 					Properties: map[string]any{
-						PersonPropertyGender: "female",
+						PersonPropertySex: "female",
 					},
 				},
 			},
@@ -86,12 +86,12 @@ func TestReconstructFamilies_WithChildren(t *testing.T) {
 			Persons: map[string]*Person{
 				"person-father": {
 					Properties: map[string]any{
-						PersonPropertyGender: "male",
+						PersonPropertySex: "male",
 					},
 				},
 				"person-mother": {
 					Properties: map[string]any{
-						PersonPropertyGender: "female",
+						PersonPropertySex: "female",
 					},
 				},
 				"person-child1": {
@@ -167,7 +167,7 @@ func TestReconstructFamilies_SingleParent(t *testing.T) {
 			Persons: map[string]*Person{
 				"person-mother": {
 					Properties: map[string]any{
-						PersonPropertyGender: "female",
+						PersonPropertySex: "female",
 					},
 				},
 				"person-child": {
@@ -221,12 +221,12 @@ func TestReconstructFamilies_SingleParentWithExistingFamily(t *testing.T) {
 			Persons: map[string]*Person{
 				"person-father": {
 					Properties: map[string]any{
-						PersonPropertyGender: "male",
+						PersonPropertySex: "male",
 					},
 				},
 				"person-mother": {
 					Properties: map[string]any{
-						PersonPropertyGender: "female",
+						PersonPropertySex: "female",
 					},
 				},
 				"person-child-married": {
@@ -330,12 +330,12 @@ func TestReconstructFamilies_PedigreeTypes(t *testing.T) {
 			Persons: map[string]*Person{
 				"person-father": {
 					Properties: map[string]any{
-						PersonPropertyGender: "male",
+						PersonPropertySex: "male",
 					},
 				},
 				"person-mother": {
 					Properties: map[string]any{
-						PersonPropertyGender: "female",
+						PersonPropertySex: "female",
 					},
 				},
 				"person-bio-child": {
@@ -426,10 +426,10 @@ func TestExportFamily_Basic(t *testing.T) {
 		GLX: &GLXFile{
 			Persons: map[string]*Person{
 				"person-husband": {
-					Properties: map[string]any{PersonPropertyGender: "male"},
+					Properties: map[string]any{PersonPropertySex: "male"},
 				},
 				"person-wife": {
-					Properties: map[string]any{PersonPropertyGender: "female"},
+					Properties: map[string]any{PersonPropertySex: "female"},
 				},
 			},
 			Relationships: map[string]*Relationship{
@@ -489,10 +489,10 @@ func TestExportFamily_WithEvents(t *testing.T) {
 		GLX: &GLXFile{
 			Persons: map[string]*Person{
 				"person-h": {
-					Properties: map[string]any{PersonPropertyGender: "male"},
+					Properties: map[string]any{PersonPropertySex: "male"},
 				},
 				"person-w": {
-					Properties: map[string]any{PersonPropertyGender: "female"},
+					Properties: map[string]any{PersonPropertySex: "female"},
 				},
 			},
 			Relationships: map[string]*Relationship{
@@ -579,10 +579,10 @@ func TestExportFamily_WithChildren(t *testing.T) {
 		GLX: &GLXFile{
 			Persons: map[string]*Person{
 				"person-h": {
-					Properties: map[string]any{PersonPropertyGender: "male"},
+					Properties: map[string]any{PersonPropertySex: "male"},
 				},
 				"person-w": {
-					Properties: map[string]any{PersonPropertyGender: "female"},
+					Properties: map[string]any{PersonPropertySex: "female"},
 				},
 				"person-c1": {
 					Properties: map[string]any{},
@@ -682,7 +682,7 @@ func TestExportPerson_FAMS_FAMC(t *testing.T) {
 					"surname": "Smith",
 				},
 			},
-			PersonPropertyGender: "male",
+			PersonPropertySex: "male",
 		},
 	}
 
@@ -792,7 +792,7 @@ func TestExportGEDCOM_FullFamily(t *testing.T) {
 							"surname": "Smith",
 						},
 					},
-					PersonPropertyGender: "male",
+					PersonPropertySex: "male",
 				},
 			},
 			"person-mother": {
@@ -804,7 +804,7 @@ func TestExportGEDCOM_FullFamily(t *testing.T) {
 							"surname": "Doe",
 						},
 					},
-					PersonPropertyGender: "female",
+					PersonPropertySex: "female",
 				},
 			},
 			"person-child": {
@@ -908,7 +908,7 @@ func TestExportGEDCOM_FamilyWithNotes(t *testing.T) {
 							"given": "Husband",
 						},
 					},
-					PersonPropertyGender: "male",
+					PersonPropertySex: "male",
 				},
 			},
 			"person-w": {
@@ -919,7 +919,7 @@ func TestExportGEDCOM_FamilyWithNotes(t *testing.T) {
 							"given": "Wife",
 						},
 					},
-					PersonPropertyGender: "female",
+					PersonPropertySex: "female",
 				},
 			},
 		},
@@ -954,10 +954,10 @@ func TestExportFamily_WithFamilyEvents(t *testing.T) {
 		GLX: &GLXFile{
 			Persons: map[string]*Person{
 				"person-h": {
-					Properties: map[string]any{PersonPropertyGender: "male"},
+					Properties: map[string]any{PersonPropertySex: "male"},
 				},
 				"person-w": {
-					Properties: map[string]any{PersonPropertyGender: "female"},
+					Properties: map[string]any{PersonPropertySex: "female"},
 				},
 			},
 			Relationships: map[string]*Relationship{
@@ -1038,8 +1038,8 @@ func TestAssignHusbandWife_MaleFemale(t *testing.T) {
 	expCtx := &ExportContext{
 		GLX: &GLXFile{
 			Persons: map[string]*Person{
-				"a": {Properties: map[string]any{PersonPropertyGender: "male"}},
-				"b": {Properties: map[string]any{PersonPropertyGender: "female"}},
+				"a": {Properties: map[string]any{PersonPropertySex: "male"}},
+				"b": {Properties: map[string]any{PersonPropertySex: "female"}},
 			},
 		},
 	}
@@ -1053,8 +1053,8 @@ func TestAssignHusbandWife_FemaleFirst(t *testing.T) {
 	expCtx := &ExportContext{
 		GLX: &GLXFile{
 			Persons: map[string]*Person{
-				"a": {Properties: map[string]any{PersonPropertyGender: "female"}},
-				"b": {Properties: map[string]any{PersonPropertyGender: "male"}},
+				"a": {Properties: map[string]any{PersonPropertySex: "female"}},
+				"b": {Properties: map[string]any{PersonPropertySex: "male"}},
 			},
 		},
 	}
@@ -1068,8 +1068,8 @@ func TestAssignHusbandWife_SameGender(t *testing.T) {
 	expCtx := &ExportContext{
 		GLX: &GLXFile{
 			Persons: map[string]*Person{
-				"a": {Properties: map[string]any{PersonPropertyGender: "male"}},
-				"b": {Properties: map[string]any{PersonPropertyGender: "male"}},
+				"a": {Properties: map[string]any{PersonPropertySex: "male"}},
+				"b": {Properties: map[string]any{PersonPropertySex: "male"}},
 			},
 		},
 	}
@@ -1237,8 +1237,8 @@ func TestExportFamily_FamilyEventsPreserveEventProperties(t *testing.T) {
 	expCtx := &ExportContext{
 		GLX: &GLXFile{
 			Persons: map[string]*Person{
-				"person-h": {Properties: map[string]any{PersonPropertyGender: "male"}},
-				"person-w": {Properties: map[string]any{PersonPropertyGender: "female"}},
+				"person-h": {Properties: map[string]any{PersonPropertySex: "male"}},
+				"person-w": {Properties: map[string]any{PersonPropertySex: "female"}},
 			},
 			Relationships: map[string]*Relationship{
 				"rel-1": {
@@ -1322,7 +1322,7 @@ func TestReconstructFamilies_MultipleSingleSpouseMarriages(t *testing.T) {
 			Persons: map[string]*Person{
 				"person-father": {
 					Properties: map[string]any{
-						PersonPropertyGender: "male",
+						PersonPropertySex: "male",
 					},
 				},
 				"person-child-a": {

--- a/go-glx/gedcom_export_person.go
+++ b/go-glx/gedcom_export_person.go
@@ -402,6 +402,10 @@ func parseValueToGEDCOMName(value string) string {
 // mapSexToGEDCOM converts a GLX sex (or gender, as fallback) value to a GEDCOM SEX value.
 // Uses the sex_types vocabulary for lookup; falls back to gender_types, then
 // to hardcoded mappings for standard values when no vocabulary entry exists.
+//
+// `not_recorded` maps to "N" for GEDCOM 5.5.x, which is the spec's Not
+// Recorded value. GEDCOM 7.0 restricts SEX to M/F/X/U, so on 7.0 exports
+// `not_recorded` collapses to "U" to keep the output valid.
 func mapSexToGEDCOM(value string, expCtx *ExportContext) string {
 	if expCtx != nil && expCtx.GLX != nil {
 		if expCtx.GLX.SexTypes != nil {
@@ -424,6 +428,10 @@ func mapSexToGEDCOM(value string, expCtx *ExportContext) string {
 	case SexOther:
 		return "X"
 	case SexNotRecorded:
+		if expCtx != nil && expCtx.Version == GEDCOM70 {
+			return "U"
+		}
+
 		return "N"
 	default:
 		return "U"

--- a/go-glx/gedcom_export_person.go
+++ b/go-glx/gedcom_export_person.go
@@ -423,6 +423,8 @@ func mapSexToGEDCOM(value string, expCtx *ExportContext) string {
 		return "F"
 	case SexOther:
 		return "X"
+	case SexNotRecorded:
+		return "N"
 	default:
 		return "U"
 	}

--- a/go-glx/gedcom_export_person.go
+++ b/go-glx/gedcom_export_person.go
@@ -23,6 +23,7 @@ import (
 // Properties that are handled specially and should not be exported as generic tags.
 var skipPersonProperties = map[string]bool{
 	PersonPropertyName:         true,
+	PersonPropertySex:          true,
 	PersonPropertyGender:       true,
 	DeprecatedPropertyBornOn:   true,
 	DeprecatedPropertyBornAt:   true,
@@ -126,10 +127,15 @@ func exportPerson(personID string, person *Person, expCtx *ExportContext) *GEDCO
 	}
 
 	// SEX
-	if gender, ok := getStringProperty(person.Properties, PersonPropertyGender); ok {
+	if sex, ok := getStringProperty(person.Properties, PersonPropertySex); ok {
 		record.SubRecords = append(record.SubRecords, &GEDCOMRecord{
 			Tag:   GedcomTagSex,
-			Value: mapGenderToSex(gender, expCtx),
+			Value: mapSexToGEDCOM(sex, expCtx),
+		})
+	} else if gender, ok := getStringProperty(person.Properties, PersonPropertyGender); ok {
+		record.SubRecords = append(record.SubRecords, &GEDCOMRecord{
+			Tag:   GedcomTagSex,
+			Value: mapSexToGEDCOM(gender, expCtx),
 		})
 	}
 
@@ -393,24 +399,29 @@ func parseValueToGEDCOMName(value string) string {
 	return given + " /" + surname + "/"
 }
 
-// mapGenderToSex converts a GLX gender value to a GEDCOM SEX value.
-// Uses the gender_types vocabulary for lookup; falls back to hardcoded
-// mapping for standard values when the vocabulary is not loaded.
-func mapGenderToSex(gender string, expCtx *ExportContext) string {
-	// Try vocabulary lookup first
-	if expCtx != nil && expCtx.GLX != nil && expCtx.GLX.GenderTypes != nil {
-		if genderType, ok := expCtx.GLX.GenderTypes[gender]; ok && genderType != nil && genderType.GEDCOM != "" {
-			return genderType.GEDCOM
+// mapSexToGEDCOM converts a GLX sex (or gender, as fallback) value to a GEDCOM SEX value.
+// Uses the sex_types vocabulary for lookup; falls back to gender_types, then
+// to hardcoded mappings for standard values when no vocabulary entry exists.
+func mapSexToGEDCOM(value string, expCtx *ExportContext) string {
+	if expCtx != nil && expCtx.GLX != nil {
+		if expCtx.GLX.SexTypes != nil {
+			if sexType, ok := expCtx.GLX.SexTypes[value]; ok && sexType != nil && sexType.GEDCOM != "" {
+				return sexType.GEDCOM
+			}
+		}
+		if expCtx.GLX.GenderTypes != nil {
+			if genderType, ok := expCtx.GLX.GenderTypes[value]; ok && genderType != nil && genderType.GEDCOM != "" {
+				return genderType.GEDCOM
+			}
 		}
 	}
 
-	// Fallback for standard values
-	switch gender {
-	case GenderMale:
+	switch value {
+	case SexMale:
 		return "M"
-	case GenderFemale:
+	case SexFemale:
 		return "F"
-	case GenderOther:
+	case SexOther:
 		return "X"
 	default:
 		return "U"

--- a/go-glx/gedcom_export_person.go
+++ b/go-glx/gedcom_export_person.go
@@ -404,35 +404,52 @@ func parseValueToGEDCOMName(value string) string {
 // to hardcoded mappings for standard values when no vocabulary entry exists.
 //
 // `not_recorded` maps to "N" for GEDCOM 5.5.x, which is the spec's Not
-// Recorded value. GEDCOM 7.0 restricts SEX to M/F/X/U, so on 7.0 exports
-// `not_recorded` collapses to "U" to keep the output valid.
+// Recorded value. GEDCOM 7.0 restricts SEX to M/F/X/U, so any mapping that
+// would emit "N" (either from a custom vocabulary entry or the built-in
+// `not_recorded` fallback) collapses to "U" on 7.0 exports to keep the
+// output valid.
 func mapSexToGEDCOM(value string, expCtx *ExportContext) string {
 	if expCtx != nil && expCtx.GLX != nil {
 		if expCtx.GLX.SexTypes != nil {
 			if sexType, ok := expCtx.GLX.SexTypes[value]; ok && sexType != nil && sexType.GEDCOM != "" {
-				return sexType.GEDCOM
+				return normalizeGEDCOMSex(sexType.GEDCOM, expCtx)
 			}
 		}
 		if expCtx.GLX.GenderTypes != nil {
 			if genderType, ok := expCtx.GLX.GenderTypes[value]; ok && genderType != nil && genderType.GEDCOM != "" {
-				return genderType.GEDCOM
+				return normalizeGEDCOMSex(genderType.GEDCOM, expCtx)
 			}
 		}
 	}
 
+	var out string
 	switch value {
 	case SexMale:
-		return "M"
+		out = "M"
 	case SexFemale:
-		return "F"
+		out = "F"
 	case SexOther:
-		return "X"
+		out = "X"
 	case SexNotRecorded:
-		if expCtx != nil && expCtx.Version == GEDCOM70 {
-			return "U"
-		}
+		out = "N"
+	default:
+		out = "U"
+	}
 
-		return "N"
+	return normalizeGEDCOMSex(out, expCtx)
+}
+
+// normalizeGEDCOMSex enforces the per-version SEX enumeration. GEDCOM 7.0
+// restricts SEX to M/F/X/U; any other value — including "N" from GEDCOM
+// 5.5.x or a custom vocabulary entry — collapses to "U" on a 7.0 export.
+// Earlier versions (and the nil/default case) preserve the value as-is.
+func normalizeGEDCOMSex(value string, expCtx *ExportContext) string {
+	if expCtx == nil || expCtx.Version != GEDCOM70 {
+		return value
+	}
+	switch value {
+	case "M", "F", "X", "U":
+		return value
 	default:
 		return "U"
 	}

--- a/go-glx/gedcom_export_roundtrip_test.go
+++ b/go-glx/gedcom_export_roundtrip_test.go
@@ -114,13 +114,13 @@ func TestRoundtrip_MinimalFamily(t *testing.T) {
 		switch {
 		case strings.Contains(name, "John") && strings.Contains(name, "Smith"):
 			foundJohn = true
-			assert.Equal(t, "male", testGetPersonGender(person))
+			assert.Equal(t, "male", testGetPersonSex(person))
 		case strings.Contains(name, "Mary") && strings.Contains(name, "Jones"):
 			foundMary = true
-			assert.Equal(t, "female", testGetPersonGender(person))
+			assert.Equal(t, "female", testGetPersonSex(person))
 		case strings.Contains(name, "James") && strings.Contains(name, "Smith"):
 			foundJames = true
-			assert.Equal(t, "male", testGetPersonGender(person))
+			assert.Equal(t, "male", testGetPersonSex(person))
 		}
 	}
 	assert.True(t, foundJohn, "John Smith not found after roundtrip")
@@ -451,19 +451,19 @@ func getPersonNameValue(person *Person) string {
 	return ""
 }
 
-// testGetPersonGender extracts the gender from a person's properties
-func testGetPersonGender(person *Person) string {
+// testGetPersonSex extracts the recorded sex from a person's properties.
+func testGetPersonSex(person *Person) string {
 	if person == nil || person.Properties == nil {
 		return ""
 	}
 
-	genderRaw, ok := person.Properties[PersonPropertyGender]
+	sexRaw, ok := person.Properties[PersonPropertySex]
 	if !ok {
 		return ""
 	}
 
-	if g, ok := genderRaw.(string); ok {
-		return g
+	if s, ok := sexRaw.(string); ok {
+		return s
 	}
 
 	return ""

--- a/go-glx/gedcom_export_test.go
+++ b/go-glx/gedcom_export_test.go
@@ -1990,18 +1990,18 @@ func TestExportPerson_NameFormat(t *testing.T) {
 	}
 }
 
-func TestMapGenderToSex(t *testing.T) {
+func TestMapSexToGEDCOM(t *testing.T) {
 	// Test fallback path (nil context)
-	assert.Equal(t, "M", mapGenderToSex("male", nil))
-	assert.Equal(t, "F", mapGenderToSex("female", nil))
-	assert.Equal(t, "X", mapGenderToSex("other", nil))
-	assert.Equal(t, "U", mapGenderToSex("unknown", nil))
-	assert.Equal(t, "U", mapGenderToSex("", nil))
+	assert.Equal(t, "M", mapSexToGEDCOM("male", nil))
+	assert.Equal(t, "F", mapSexToGEDCOM("female", nil))
+	assert.Equal(t, "X", mapSexToGEDCOM("other", nil))
+	assert.Equal(t, "U", mapSexToGEDCOM("unknown", nil))
+	assert.Equal(t, "U", mapSexToGEDCOM("", nil))
 
-	// Test vocabulary lookup path
+	// Test vocabulary lookup path (sex_types preferred)
 	expCtx := &ExportContext{
 		GLX: &GLXFile{
-			GenderTypes: map[string]*GenderType{
+			SexTypes: map[string]*SexType{
 				"male":       {Label: "Male", GEDCOM: "M"},
 				"female":     {Label: "Female", GEDCOM: "F"},
 				"custom":     {Label: "Custom", GEDCOM: "X"},
@@ -2009,18 +2009,28 @@ func TestMapGenderToSex(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, "M", mapGenderToSex("male", expCtx))
-	assert.Equal(t, "F", mapGenderToSex("female", expCtx))
-	assert.Equal(t, "X", mapGenderToSex("custom", expCtx))
+	assert.Equal(t, "M", mapSexToGEDCOM("male", expCtx))
+	assert.Equal(t, "F", mapSexToGEDCOM("female", expCtx))
+	assert.Equal(t, "X", mapSexToGEDCOM("custom", expCtx))
 	// Falls back to default for values not in vocab
-	assert.Equal(t, "U", mapGenderToSex("nonexistent", expCtx))
+	assert.Equal(t, "U", mapSexToGEDCOM("nonexistent", expCtx))
 	// Falls back to default when vocab entry has empty GEDCOM field
-	assert.Equal(t, "U", mapGenderToSex("no_mapping", expCtx))
+	assert.Equal(t, "U", mapSexToGEDCOM("no_mapping", expCtx))
 
 	// Test with non-nil context but nil GLX
 	expCtxNilGLX := &ExportContext{GLX: nil}
-	assert.Equal(t, "M", mapGenderToSex("male", expCtxNilGLX))
-	assert.Equal(t, "U", mapGenderToSex("unknown", expCtxNilGLX))
+	assert.Equal(t, "M", mapSexToGEDCOM("male", expCtxNilGLX))
+	assert.Equal(t, "U", mapSexToGEDCOM("unknown", expCtxNilGLX))
+
+	// Falls back to gender_types when sex_types lacks the key (back-compat).
+	expCtxGender := &ExportContext{
+		GLX: &GLXFile{
+			GenderTypes: map[string]*GenderType{
+				"legacy": {Label: "Legacy", GEDCOM: "X"},
+			},
+		},
+	}
+	assert.Equal(t, "X", mapSexToGEDCOM("legacy", expCtxGender))
 }
 
 func TestBuildPersonEventsIndex(t *testing.T) {

--- a/go-glx/gedcom_export_test.go
+++ b/go-glx/gedcom_export_test.go
@@ -1996,6 +1996,7 @@ func TestMapSexToGEDCOM(t *testing.T) {
 	assert.Equal(t, "F", mapSexToGEDCOM("female", nil))
 	assert.Equal(t, "X", mapSexToGEDCOM("other", nil))
 	assert.Equal(t, "U", mapSexToGEDCOM("unknown", nil))
+	assert.Equal(t, "N", mapSexToGEDCOM("not_recorded", nil))
 	assert.Equal(t, "U", mapSexToGEDCOM("", nil))
 
 	// Test vocabulary lookup path (sex_types preferred)

--- a/go-glx/gedcom_export_test.go
+++ b/go-glx/gedcom_export_test.go
@@ -2032,6 +2032,14 @@ func TestMapSexToGEDCOM(t *testing.T) {
 		},
 	}
 	assert.Equal(t, "X", mapSexToGEDCOM("legacy", expCtxGender))
+
+	// not_recorded is version-dependent: "N" is a GEDCOM 5.5.x value and not
+	// valid in GEDCOM 7.0 (M/F/X/U only), so it collapses to "U" on 7.0
+	// exports.
+	expCtx551 := &ExportContext{GLX: &GLXFile{}, Version: GEDCOM551}
+	assert.Equal(t, "N", mapSexToGEDCOM("not_recorded", expCtx551))
+	expCtx70 := &ExportContext{GLX: &GLXFile{}, Version: GEDCOM70}
+	assert.Equal(t, "U", mapSexToGEDCOM("not_recorded", expCtx70))
 }
 
 func TestBuildPersonEventsIndex(t *testing.T) {

--- a/go-glx/gedcom_export_test.go
+++ b/go-glx/gedcom_export_test.go
@@ -2040,6 +2040,28 @@ func TestMapSexToGEDCOM(t *testing.T) {
 	assert.Equal(t, "N", mapSexToGEDCOM("not_recorded", expCtx551))
 	expCtx70 := &ExportContext{GLX: &GLXFile{}, Version: GEDCOM70}
 	assert.Equal(t, "U", mapSexToGEDCOM("not_recorded", expCtx70))
+
+	// Vocabulary-provided values are also clamped to 7.0's enum — a custom
+	// sex_types entry with gedcom: "N" must NOT leak into a 7.0 export.
+	expCtx70WithCustomN := &ExportContext{
+		GLX: &GLXFile{
+			SexTypes: map[string]*SexType{
+				"legacy_n": {Label: "Legacy N", GEDCOM: "N"},
+				"legacy_z": {Label: "Legacy Z", GEDCOM: "Z"},
+			},
+		},
+		Version: GEDCOM70,
+	}
+	assert.Equal(t, "U", mapSexToGEDCOM("legacy_n", expCtx70WithCustomN))
+	assert.Equal(t, "U", mapSexToGEDCOM("legacy_z", expCtx70WithCustomN))
+
+	// On 5.5.1 the vocabulary mapping is preserved verbatim.
+	expCtx551WithCustomN := &ExportContext{
+		GLX:     expCtx70WithCustomN.GLX,
+		Version: GEDCOM551,
+	}
+	assert.Equal(t, "N", mapSexToGEDCOM("legacy_n", expCtx551WithCustomN))
+	assert.Equal(t, "Z", mapSexToGEDCOM("legacy_z", expCtx551WithCustomN))
 }
 
 func TestBuildPersonEventsIndex(t *testing.T) {

--- a/go-glx/gedcom_import_test.go
+++ b/go-glx/gedcom_import_test.go
@@ -1018,9 +1018,9 @@ func TestImportSex_UnrecognizedValuePreserved(t *testing.T) {
 	require.Len(t, glxFile.Persons, 1, "should import exactly one person")
 
 	for _, person := range glxFile.Persons {
-		gender, ok := person.Properties[PersonPropertyGender].(string)
-		require.True(t, ok, "gender property should be a string")
-		assert.Equal(t, "n", gender, "unrecognized SEX value 'N' should be preserved as 'n', not mapped to 'unknown'")
+		sex, ok := person.Properties[PersonPropertySex].(string)
+		require.True(t, ok, "sex property should be a string")
+		assert.Equal(t, "n", sex, "unrecognized SEX value 'N' should be preserved as 'n', not mapped to 'unknown'")
 	}
 }
 

--- a/go-glx/gedcom_import_test.go
+++ b/go-glx/gedcom_import_test.go
@@ -1001,10 +1001,10 @@ func TestImportASSOEvent_MissingPersonWarning(t *testing.T) {
 	assert.True(t, foundWarning, "missing ASSO reference should produce a warning")
 }
 
-// TestImportSex_UnrecognizedValuePreserved tests that non-standard GEDCOM SEX
-// values are preserved as lowercase instead of being silently mapped to "unknown".
-// Fixes #520.
-func TestImportSex_UnrecognizedValuePreserved(t *testing.T) {
+// TestImportSex_NRecordedMapsToNotRecorded tests that GEDCOM 5.5.5 `SEX N`
+// (Not Recorded) maps to the GLX `not_recorded` sex value rather than being
+// silently mapped to `unknown` or preserved as raw "n". See #520, #528.
+func TestImportSex_NRecordedMapsToNotRecorded(t *testing.T) {
 	gedcom := `0 HEAD
 1 GEDC
 2 VERS 7.0
@@ -1020,7 +1020,7 @@ func TestImportSex_UnrecognizedValuePreserved(t *testing.T) {
 	for _, person := range glxFile.Persons {
 		sex, ok := person.Properties[PersonPropertySex].(string)
 		require.True(t, ok, "sex property should be a string")
-		assert.Equal(t, "n", sex, "unrecognized SEX value 'N' should be preserved as 'n', not mapped to 'unknown'")
+		assert.Equal(t, SexNotRecorded, sex, "GEDCOM 'SEX N' should map to not_recorded")
 	}
 }
 

--- a/go-glx/gedcom_import_test.go
+++ b/go-glx/gedcom_import_test.go
@@ -1024,6 +1024,31 @@ func TestImportSex_NRecordedMapsToNotRecorded(t *testing.T) {
 	}
 }
 
+// TestImportSex_UnrecognizedValuePreservedLowercase tests that GEDCOM SEX
+// values outside the known enumeration (M/F/U/X/N) are preserved in the
+// `sex` property as lowercase strings rather than being flattened to
+// `unknown`. This keeps unfamiliar enumeration extensions round-trippable
+// and lets validation warn on the out-of-vocabulary value (#520).
+func TestImportSex_UnrecognizedValuePreservedLowercase(t *testing.T) {
+	gedcom := `0 HEAD
+1 GEDC
+2 VERS 7.0
+0 @I1@ INDI
+1 NAME Test /Person/
+1 SEX Q
+0 TRLR`
+
+	glxFile, _, err := ImportGEDCOM(strings.NewReader(gedcom), nil)
+	require.NoError(t, err)
+	require.Len(t, glxFile.Persons, 1, "should import exactly one person")
+
+	for _, person := range glxFile.Persons {
+		sex, ok := person.Properties[PersonPropertySex].(string)
+		require.True(t, ok, "sex property should be a string")
+		assert.Equal(t, "q", sex, "unrecognized GEDCOM SEX should be preserved lowercase")
+	}
+}
+
 func TestImportDate_CalendarEscapePreserved(t *testing.T) {
 	gedcom := "0 HEAD\n1 GEDC\n2 VERS 5.5.1\n" +
 		"0 @I1@ INDI\n1 NAME John /Smith/\n" +

--- a/go-glx/gedcom_individual.go
+++ b/go-glx/gedcom_individual.go
@@ -306,6 +306,9 @@ func convertIndividualEvent(personID string, person *Person, eventRecord *GEDCOM
 }
 
 // mapGEDCOMSex maps GEDCOM SEX values to GLX sex property values.
+// "N" maps to SexNotRecorded per GEDCOM 5.5.5 — the source did not contain
+// a sex field. Unrecognized values are preserved as lowercase so the data
+// is not lost; validation will warn about unknown sex types (#520).
 func mapGEDCOMSex(sex string) string {
 	switch strings.ToUpper(sex) {
 	case "M":
@@ -316,15 +319,14 @@ func mapGEDCOMSex(sex string) string {
 		return SexUnknown
 	case "X":
 		return SexOther
+	case "N":
+		return SexNotRecorded
 	default:
-		// Preserve unrecognized values as lowercase so the data is not lost.
-		// Validation will warn about unknown sex types. Fixes #520.
-		// Note: GEDCOM export maps unknown values to SEX U; true roundtrip
-		// requires a custom sex_types vocabulary entry with a gedcom: field.
 		trimmed := strings.ToLower(strings.TrimSpace(sex))
 		if trimmed == "" {
 			return SexUnknown
 		}
+
 		return trimmed
 	}
 }

--- a/go-glx/gedcom_individual.go
+++ b/go-glx/gedcom_individual.go
@@ -73,12 +73,12 @@ func convertIndividual(indiRecord *GEDCOMRecord, conv *ConversionContext) error 
 			createNameAssertion(personID, parsedName, sub, conv)
 
 		case GedcomTagSex:
-			// Gender mapping
-			gender := mapGEDCOMSex(sub.Value)
-			person.Properties[PersonPropertyGender] = gender
+			// Sex mapping (what the source recorded)
+			sex := mapGEDCOMSex(sub.Value)
+			person.Properties[PersonPropertySex] = sex
 
 			// Create assertion
-			createPropertyAssertion(personID, PersonPropertyGender, gender, sub, conv)
+			createPropertyAssertion(personID, PersonPropertySex, sex, sub, conv)
 
 		case GedcomTagBirt, GedcomTagChr, GedcomTagDeat, GedcomTagBuri, GedcomTagCrem, GedcomTagAdop, GedcomTagBapm, GedcomTagBarm, GedcomTagBatm, GedcomTagBasm,
 			GedcomTagBles, GedcomTagChra, GedcomTagConf, GedcomTagFcom, GedcomTagOrdn, GedcomTagNatu, GedcomTagEmig, GedcomTagImmi,
@@ -305,25 +305,25 @@ func convertIndividualEvent(personID string, person *Person, eventRecord *GEDCOM
 	return nil
 }
 
-// mapGEDCOMSex maps GEDCOM sex values to GLX gender
+// mapGEDCOMSex maps GEDCOM SEX values to GLX sex property values.
 func mapGEDCOMSex(sex string) string {
 	switch strings.ToUpper(sex) {
 	case "M":
-		return GenderMale
+		return SexMale
 	case "F":
-		return GenderFemale
+		return SexFemale
 	case "U":
-		return GenderUnknown
+		return SexUnknown
 	case "X":
-		return GenderOther
+		return SexOther
 	default:
 		// Preserve unrecognized values as lowercase so the data is not lost.
-		// Validation will warn about unknown gender types. Fixes #520.
+		// Validation will warn about unknown sex types. Fixes #520.
 		// Note: GEDCOM export maps unknown values to SEX U; true roundtrip
-		// requires a custom gender_types vocabulary entry with a gedcom: field.
+		// requires a custom sex_types vocabulary entry with a gedcom: field.
 		trimmed := strings.ToLower(strings.TrimSpace(sex))
 		if trimmed == "" {
-			return GenderUnknown
+			return SexUnknown
 		}
 		return trimmed
 	}

--- a/go-glx/gedcom_integration_test.go
+++ b/go-glx/gedcom_integration_test.go
@@ -92,12 +92,12 @@ func TestImportShakespeare(t *testing.T) {
 		if givenName == "William" && familyName == "Shakespeare" {
 			foundWilliam = true
 
-			// Verify gender
-			if gender, ok := person.Properties[PersonPropertyGender].(string); !ok || gender != "male" {
-				t.Error("William Shakespeare should have gender 'male'")
+			// Verify recorded sex
+			if sex, ok := person.Properties[PersonPropertySex].(string); !ok || sex != "male" {
+				t.Error("William Shakespeare should have sex 'male'")
 			}
 
-			t.Logf("✓ Found William Shakespeare with correct name and gender")
+			t.Logf("✓ Found William Shakespeare with correct name and sex")
 
 			break
 		}

--- a/go-glx/serializer.go
+++ b/go-glx/serializer.go
@@ -280,6 +280,7 @@ func (s *DefaultSerializer) DeserializeMultiFileFromMap(files map[string][]byte)
 		SourceTypes:       make(map[string]*SourceType),
 		RepositoryTypes:   make(map[string]*RepositoryType),
 		MediaTypes:        make(map[string]*MediaType),
+		SexTypes:          make(map[string]*SexType),
 		GenderTypes:       make(map[string]*GenderType),
 
 		PersonProperties:       make(map[string]*PropertyDefinition),

--- a/go-glx/types.go
+++ b/go-glx/types.go
@@ -84,6 +84,7 @@ type GLXFile struct { //nolint:revive // GLXFile is the established name across 
 	SourceTypes       map[string]*SourceType       `yaml:"source_types,omitempty"`
 	RepositoryTypes   map[string]*RepositoryType   `yaml:"repository_types,omitempty"`
 	MediaTypes        map[string]*MediaType        `yaml:"media_types,omitempty"`
+	SexTypes          map[string]*SexType          `yaml:"sex_types,omitempty"`
 	GenderTypes       map[string]*GenderType       `yaml:"gender_types,omitempty"`
 
 	// Property vocabularies
@@ -369,7 +370,17 @@ type MediaType struct {
 	GEDCOM      string `yaml:"gedcom,omitempty"`
 }
 
-// GenderType represents a standard gender type vocabulary entry.
+// SexType represents a standard sex type vocabulary entry for the person `sex`
+// property. Sex values are recorded from source documents and map to GEDCOM SEX.
+type SexType struct {
+	Label       string `yaml:"label"`
+	Description string `yaml:"description,omitempty"`
+	GEDCOM      string `yaml:"gedcom,omitempty"`
+}
+
+// GenderType represents a standard gender identity vocabulary entry for the
+// person `gender` property. GEDCOM has no standard tag for gender identity and
+// defers to FACT, so the GEDCOM field is optional.
 type GenderType struct {
 	Label       string `yaml:"label"`
 	Description string `yaml:"description,omitempty"`
@@ -448,6 +459,7 @@ func (g *GLXFile) Merge(other *GLXFile) (conflicts []string, identicalSkipped in
 	addDedup(mergeMapDedup("source_types", g.SourceTypes, other.SourceTypes))
 	addDedup(mergeMapDedup("repository_types", g.RepositoryTypes, other.RepositoryTypes))
 	addDedup(mergeMapDedup("media_types", g.MediaTypes, other.MediaTypes))
+	addDedup(mergeMapDedup("sex_types", g.SexTypes, other.SexTypes))
 	addDedup(mergeMapDedup("gender_types", g.GenderTypes, other.GenderTypes))
 	addDedup(mergeMapDedup("participant_roles", g.ParticipantRoles, other.ParticipantRoles))
 	addDedup(mergeMapDedup("confidence_levels", g.ConfidenceLevels, other.ConfidenceLevels))
@@ -514,6 +526,9 @@ func (g *GLXFile) initMaps() {
 	}
 	if g.MediaTypes == nil {
 		g.MediaTypes = make(map[string]*MediaType)
+	}
+	if g.SexTypes == nil {
+		g.SexTypes = make(map[string]*SexType)
 	}
 	if g.GenderTypes == nil {
 		g.GenderTypes = make(map[string]*GenderType)

--- a/go-glx/types_merge_test.go
+++ b/go-glx/types_merge_test.go
@@ -199,6 +199,7 @@ func TestGLXFile_Merge_AllVocabularyTypes(t *testing.T) {
 		MediaTypes:        map[string]*MediaType{"type-1": {}},
 		ParticipantRoles:  map[string]*ParticipantRole{"role-1": {}},
 		ConfidenceLevels:  map[string]*ConfidenceLevel{"level-1": {}},
+		SexTypes:          map[string]*SexType{"sex-1": {}},
 		GenderTypes:       map[string]*GenderType{"gender-1": {}},
 	}
 
@@ -211,6 +212,7 @@ func TestGLXFile_Merge_AllVocabularyTypes(t *testing.T) {
 		MediaTypes:        map[string]*MediaType{"type-2": {}},
 		ParticipantRoles:  map[string]*ParticipantRole{"role-2": {}},
 		ConfidenceLevels:  map[string]*ConfidenceLevel{"level-2": {}},
+		SexTypes:          map[string]*SexType{"sex-2": {}},
 		GenderTypes:       map[string]*GenderType{"gender-2": {}},
 	}
 
@@ -226,6 +228,7 @@ func TestGLXFile_Merge_AllVocabularyTypes(t *testing.T) {
 	require.Len(t, g1.MediaTypes, 2)
 	require.Len(t, g1.ParticipantRoles, 2)
 	require.Len(t, g1.ConfidenceLevels, 2)
+	require.Len(t, g1.SexTypes, 2)
 	require.Len(t, g1.GenderTypes, 2)
 }
 

--- a/go-glx/validation.go
+++ b/go-glx/validation.go
@@ -90,6 +90,7 @@ func (glx *GLXFile) buildVocabularyMaps(result *ValidationResult) {
 	result.Vocabularies[VocabMediaTypes] = buildIDSet(glx.MediaTypes)
 	result.Vocabularies[VocabConfidenceLevels] = buildIDSet(glx.ConfidenceLevels)
 	result.Vocabularies[VocabSourceTypes] = buildIDSet(glx.SourceTypes)
+	result.Vocabularies[VocabSexTypes] = buildIDSet(glx.SexTypes)
 	result.Vocabularies[VocabGenderTypes] = buildIDSet(glx.GenderTypes)
 }
 

--- a/go-glx/validation_test.go
+++ b/go-glx/validation_test.go
@@ -1455,3 +1455,21 @@ func TestValidatePropertyVocabularyValue(t *testing.T) {
 		assert.Contains(t, warn.Message, "conflicting type fields")
 	})
 }
+
+func TestValidateStandardSexAndGenderVocabs(t *testing.T) {
+	var archive GLXFile
+	if err := LoadStandardVocabulariesIntoGLX(&archive); err != nil {
+		t.Fatalf("LoadStandardVocabulariesIntoGLX: %v", err)
+	}
+	archive.Persons = map[string]*Person{
+		"person-1": {Properties: map[string]any{
+			"sex":    "not_recorded",
+			"gender": "nonbinary",
+		}},
+	}
+
+	result := archive.Validate()
+	assert.Empty(t, result.Errors)
+	assert.Empty(t, result.Warnings,
+		"standard vocabularies should validate 'sex: not_recorded' and 'gender: nonbinary' without warnings")
+}

--- a/go-glx/vocabularies.go
+++ b/go-glx/vocabularies.go
@@ -88,6 +88,7 @@ func LoadStandardVocabulariesIntoGLX(glx *GLXFile) error {
 	glx.ParticipantRoles = maps.Clone(cachedVocabs.ParticipantRoles)
 	glx.MediaTypes = maps.Clone(cachedVocabs.MediaTypes)
 	glx.ConfidenceLevels = maps.Clone(cachedVocabs.ConfidenceLevels)
+	glx.SexTypes = maps.Clone(cachedVocabs.SexTypes)
 	glx.GenderTypes = maps.Clone(cachedVocabs.GenderTypes)
 	glx.PersonProperties = maps.Clone(cachedVocabs.PersonProperties)
 	glx.EventProperties = maps.Clone(cachedVocabs.EventProperties)
@@ -136,6 +137,8 @@ func loadVocabulary(filename string, data []byte, glx *GLXFile) error {
 		return unmarshalVocab(filename, data, "media_types", &glx.MediaTypes)
 	case "confidence-levels.glx":
 		return unmarshalVocab(filename, data, "confidence_levels", &glx.ConfidenceLevels)
+	case "sex-types.glx":
+		return unmarshalVocab(filename, data, "sex_types", &glx.SexTypes)
 	case "gender-types.glx":
 		return unmarshalVocab(filename, data, "gender_types", &glx.GenderTypes)
 	case "person-properties.glx":

--- a/go-glx/vocabularies_test.go
+++ b/go-glx/vocabularies_test.go
@@ -44,6 +44,7 @@ func TestStandardVocabularies(t *testing.T) {
 		"event-properties.glx",
 		"relationship-properties.glx",
 		"place-properties.glx",
+		"sex-types.glx",
 		"gender-types.glx",
 	}
 
@@ -219,3 +220,31 @@ func TestLoadStandardVocabulariesIntoGLX_ClonedMaps(t *testing.T) {
 // These tests were removed because WriteStandardVocabularies and WriteVocabulariesToFile
 // were removed from lib (they violated the no-I/O rule). Vocabulary writing is now
 // handled by the CLI commands, and vocabulary serialization is tested in roundtrip tests.
+
+func TestLoadStandardVocabularies_PopulatesSexAndGenderTypes(t *testing.T) {
+	var glx GLXFile
+	if err := LoadStandardVocabulariesIntoGLX(&glx); err != nil {
+		t.Fatalf("LoadStandardVocabulariesIntoGLX: %v", err)
+	}
+
+	for _, key := range []string{"male", "female", "unknown", "not_recorded", "other"} {
+		if _, ok := glx.SexTypes[key]; !ok {
+			t.Errorf("sex_types missing standard entry %q", key)
+		}
+	}
+	if glx.SexTypes["male"].GEDCOM != "M" {
+		t.Errorf("expected sex_types.male.gedcom == M, got %q", glx.SexTypes["male"].GEDCOM)
+	}
+	if glx.SexTypes["not_recorded"].GEDCOM != "" {
+		t.Errorf("expected sex_types.not_recorded.gedcom empty, got %q", glx.SexTypes["not_recorded"].GEDCOM)
+	}
+
+	for _, key := range []string{"male", "female", "nonbinary", "other"} {
+		if _, ok := glx.GenderTypes[key]; !ok {
+			t.Errorf("gender_types missing standard entry %q", key)
+		}
+	}
+	if _, ok := glx.GenderTypes["unknown"]; ok {
+		t.Error("gender_types should no longer contain 'unknown' (moved to sex_types)")
+	}
+}

--- a/specification/4-entity-types/person.md
+++ b/specification/4-entity-types/person.md
@@ -44,7 +44,7 @@ persons:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `properties` | object | Vocabulary-defined properties (name, gender, occupation, etc.) |
+| `properties` | object | Vocabulary-defined properties (name, sex, gender, occupation, etc.) |
 | `notes` | string \| string[] | Free-form notes about the person |
 
 > **Note:** While no properties are technically required, the `name` property is recommended for most person records as it enables meaningful identification and display.
@@ -78,7 +78,8 @@ properties:
       surname_prefix: String  # e.g., von, van, de
       surname: String
       suffix: String
-  gender: String            # From person_properties vocabulary
+  sex: String               # From person_properties vocabulary (recorded in source)
+  gender: String            # From person_properties vocabulary (self-identified)
   occupation: String        # From person_properties vocabulary
   residence: "place-id"    # From person_properties vocabulary (reference)
 ```
@@ -91,7 +92,7 @@ properties:
     fields:
       given: "John"
       surname: "Smith"
-  gender: "male"
+  sex: "male"
   occupation: "blacksmith"
   residence:
     - value: "place-leeds"
@@ -100,9 +101,14 @@ properties:
       date: "FROM 1900 TO 1920"
 ```
 
-#### Gender Property
+#### Sex and Gender Properties
 
-The `gender` property is constrained by the `gender_types` vocabulary via `vocabulary_type: gender_types`. The standard vocabulary includes `male`, `female`, `unknown`, and `other` (with GEDCOM SEX mappings), but archives may extend it with additional entries. Values not found in the vocabulary produce a **warning**, not an error — this allows archives to use custom values before adding them to the vocabulary. The property is temporal, allowing changes to be recorded over time.
+GLX splits "recorded sex" and "gender identity" into two separate properties (issue #528).
+
+- **`sex`** — What the source recorded. Maps to GEDCOM `SEX` on import/export. Constrained by the `sex_types` vocabulary via `vocabulary_type: sex_types`. Standard values: `male`, `female`, `unknown`, `not_recorded`, `other` (each with GEDCOM mappings where applicable). Use `not_recorded` when the source has no sex field at all; use `unknown` when the source was consulted but the sex could not be determined.
+- **`gender`** — Self-identified gender identity. Constrained by the `gender_types` vocabulary. Standard values: `male`, `female`, `nonbinary`, `other`. No direct GEDCOM mapping (GEDCOM 7.0 defers identity to `FACT`). Primarily useful for modern records and living persons; for most historical genealogy only `sex` will be populated.
+
+Both properties are temporal, allowing changes over time. Out-of-vocabulary values produce a **warning**, not an error — archives may use custom values before adding them to the vocabulary.
 
 #### Temporal Property Examples
 
@@ -252,7 +258,7 @@ properties:
 **Key Points:**
 - All properties are optional
 - Property names and types are validated against the `person_properties` vocabulary
-- The `gender` property is constrained by the [gender types vocabulary](vocabularies#property-definition-structure) — out-of-vocabulary values produce a warning
+- The `sex` and `gender` properties are constrained by the [sex types](vocabularies#sex-types-vocabulary) and [gender types](vocabularies#gender-types-vocabulary) vocabularies — out-of-vocabulary values produce a warning
 - Properties can be temporal (change over time) - see [Core Concepts - Data Types](../2-core-concepts#temporal-properties)
 - Custom properties can be added by extending the vocabulary
 - Birth and death information is stored on [Event entities](event) of type `birth` and `death`, not as person properties
@@ -271,7 +277,7 @@ persons:
         fields:
           given: "John"
           surname: "Smith"
-      gender: "male"
+      sex: "male"
 ```
 
 ### Person with Full Details
@@ -286,7 +292,7 @@ persons:
         fields:
           given: "Margaret Eleanor"
           surname: "Smith"
-      gender: "female"
+      sex: "female"
     notes: |
       Family tradition says she was named after her grandmother.
       Need to verify with census records.
@@ -314,7 +320,7 @@ persons/
 | `properties.name` | `INDI.NAME` | Person's name |
 | `properties.name.fields.given` | `INDI.NAME.GIVN` | Given name |
 | `properties.name.fields.surname` | `INDI.NAME.SURN` | Surname |
-| `properties.gender` | `INDI.SEX` | M/F mapped to male/female |
+| `properties.sex` | `INDI.SEX` | M/F/U/X mapped to male/female/unknown/other |
 | `properties.occupation` | `INDI.OCCU` | Occupation |
 | `properties.residence` | `INDI.RESI` | Residence |
 | `notes` | `INDI.NOTE` | Notes |

--- a/specification/4-entity-types/person.md
+++ b/specification/4-entity-types/person.md
@@ -258,7 +258,7 @@ properties:
 **Key Points:**
 - All properties are optional
 - Property names and types are validated against the `person_properties` vocabulary
-- The `sex` and `gender` properties are constrained by the [sex types](vocabularies#sex-types-vocabulary) and [gender types](vocabularies#gender-types-vocabulary) vocabularies — out-of-vocabulary values produce a warning
+- The `sex` and `gender` properties are constrained by the [sex types](../5-standard-vocabularies/#sex-types) and [gender types](../5-standard-vocabularies/#gender-types) vocabularies — out-of-vocabulary values produce a warning
 - Properties can be temporal (change over time) - see [Core Concepts - Data Types](../2-core-concepts#temporal-properties)
 - Custom properties can be added by extending the vocabulary
 - Birth and death information is stored on [Event entities](event) of type `birth` and `death`, not as person properties

--- a/specification/4-entity-types/vocabularies.md
+++ b/specification/4-entity-types/vocabularies.md
@@ -40,6 +40,7 @@ The standard vocabulary files are:
 - `repository-properties.glx`
 - `source-properties.glx`
 - `citation-properties.glx`
+- `sex-types.glx`
 - `gender-types.glx`
 
 When creating an archive with `glx init` or `glx import`, these files are automatically copied from the [Standard Vocabularies](../5-standard-vocabularies/) templates into a `vocabularies/` directory. You can reorganize or relocate them as you see fit — the parser discovers vocabulary definitions by their top-level keys, not by file path.
@@ -787,9 +788,15 @@ Each property in a property vocabulary is defined with the following fields:
 
 ```yaml
 person_properties:
+  sex:
+    label: "Sex"
+    description: "Sex as recorded in source documents"
+    vocabulary_type: sex_types
+    temporal: true
+
   gender:
     label: "Gender"
-    description: "Gender identity"
+    description: "Self-identified gender identity"
     vocabulary_type: gender_types
     temporal: true
 
@@ -813,7 +820,7 @@ person_properties:
 | `description` | No | Detailed description of the property |
 | `value_type` | No* | Data type: `string`, `date`, `integer`, or `boolean` |
 | `reference_type` | No* | Entity type for references: `persons`, `places`, `events`, `relationships`, `sources`, `citations`, `repositories`, `media` |
-| `vocabulary_type` | No* | Vocabulary that constrains allowed values (e.g., `gender_types`). Values not found in the vocabulary produce a **warning**, not an error — archives may use values before adding them to their vocabulary |
+| `vocabulary_type` | No* | Vocabulary that constrains allowed values (e.g., `sex_types`, `gender_types`). Values not found in the vocabulary produce a **warning**, not an error — archives may use values before adding them to their vocabulary |
 | `temporal` | No | Whether property can change over time (default: false) |
 | `multi_value` | No | Whether property can have multiple values as an array (default: false) |
 | `gedcom` | No | Corresponding GEDCOM tag for import/export mapping (e.g., `OCCU`, `PAGE`) |

--- a/specification/5-standard-vocabularies/README.md
+++ b/specification/5-standard-vocabularies/README.md
@@ -131,9 +131,22 @@ Defines categories of institutions that hold genealogical sources (archives, lib
 
 ---
 
+### Sex Types
+
+Defines controlled values for the `sex` person property (male, female, unknown, not_recorded, other). Sex is what was recorded in source documents (e.g., GEDCOM SEX, census enumerations) and maps to GEDCOM `SEX` on import/export. Out-of-vocabulary values produce a validation warning.
+
+<YamlFile
+  :content="vocabularies['sex-types']"
+  title="vocabularies/sex-types.glx"
+/>
+
+**View Source:** [sex-types.glx](https://github.com/genealogix/glx/blob/main/specification/5-standard-vocabularies/sex-types.glx) | **See Also:** [Person Entity Documentation](../4-entity-types/person) | [Vocabularies Specification](../4-entity-types/vocabularies#property-definition-structure)
+
+---
+
 ### Gender Types
 
-Defines controlled values for the `gender` person property (male, female, unknown, other). Gender values are constrained by this vocabulary via the `vocabulary_type` mechanism — out-of-vocabulary values produce a validation warning.
+Defines controlled values for the `gender` person property — self-identified gender identity (male, female, nonbinary, other). Primarily relevant for modern records and living persons; historical genealogy typically only populates `sex`. GEDCOM has no standard tag for gender identity (it defers to `FACT`). Out-of-vocabulary values produce a validation warning.
 
 <YamlFile
   :content="vocabularies['gender-types']"
@@ -150,13 +163,14 @@ Property vocabularies define the custom properties available for each entity typ
 
 ### Person Properties
 
-Defines standard and custom properties for person entities (name, gender, occupation, residence, etc.). Supports temporal properties that change over time.
+Defines standard and custom properties for person entities (name, sex, gender, occupation, residence, etc.). Supports temporal properties that change over time.
 
 **View Source:** [person-properties.glx](https://github.com/genealogix/glx/blob/main/specification/5-standard-vocabularies/person-properties.glx)
 
 **Standard Properties Include:**
 - `name` - Unified name property with optional structured fields (type, given, surname, prefix, suffix, etc.) (temporal)
-- `gender` - Gender identity (temporal)
+- `sex` - Sex as recorded in source documents (temporal, maps to GEDCOM SEX)
+- `gender` - Self-identified gender identity (temporal; primarily for modern/living records)
 - `occupation` - Profession (temporal, GEDCOM: OCCU)
 - `title` - Nobility or honorific title (temporal, GEDCOM: TITL)
 - `residence` - Place of residence (temporal, reference)

--- a/specification/5-standard-vocabularies/embed.go
+++ b/specification/5-standard-vocabularies/embed.go
@@ -59,6 +59,11 @@ var MediaTypes []byte
 //go:embed confidence-levels.glx
 var ConfidenceLevels []byte
 
+// SexTypes contains the embedded sex-types.glx vocabulary file.
+//
+//go:embed sex-types.glx
+var SexTypes []byte
+
 // GenderTypes contains the embedded gender-types.glx vocabulary file.
 //
 //go:embed gender-types.glx
@@ -114,6 +119,7 @@ var Files = map[string][]byte{
 	"participant-roles.glx":       ParticipantRoles,
 	"media-types.glx":             MediaTypes,
 	"confidence-levels.glx":       ConfidenceLevels,
+	"sex-types.glx":               SexTypes,
 	"gender-types.glx":            GenderTypes,
 	"person-properties.glx":       PersonProperties,
 	"event-properties.glx":        EventProperties,

--- a/specification/5-standard-vocabularies/gender-types.glx
+++ b/specification/5-standard-vocabularies/gender-types.glx
@@ -1,25 +1,25 @@
 # Standard Gender Types
-# This file defines the standard gender types for GENEALOGIX archives.
+# This file defines the standard gender identity types for GENEALOGIX archives.
+# Gender values represent self-identified gender identity, primarily relevant for
+# modern records and living persons. For sex as recorded in historical sources,
+# see sex-types.glx.
 # Archives can extend this with custom types by adding additional entries.
-# Each entry includes a GEDCOM SEX mapping for interoperability.
+# GEDCOM has no direct mapping for gender identity (it defers to FACT); archives
+# may add a `gedcom:` field if they choose to export identity to a specific tag.
 
 gender_types:
   male:
     label: "Male"
-    description: "Male gender identity"
-    gedcom: "M"
+    description: "Self-identified as male"
 
   female:
     label: "Female"
-    description: "Female gender identity"
-    gedcom: "F"
+    description: "Self-identified as female"
 
-  unknown:
-    label: "Unknown"
-    description: "Gender is unknown or not recorded"
-    gedcom: "U"
+  nonbinary:
+    label: "Non-binary"
+    description: "Self-identified as non-binary"
 
   other:
     label: "Other"
-    description: "Gender not covered by other categories"
-    gedcom: "X"
+    description: "Self-identified gender outside the male/female/non-binary categories"

--- a/specification/5-standard-vocabularies/person-properties.glx
+++ b/specification/5-standard-vocabularies/person-properties.glx
@@ -32,12 +32,18 @@ person_properties:
         label: "Suffix"
         description: "Generational suffix (Jr., Sr., III)"
 
+  sex:
+    label: "Sex"
+    description: "Sex as recorded in source documents (e.g., GEDCOM SEX, census enumerations)"
+    vocabulary_type: sex_types
+    temporal: true
+
   gender:
     label: "Gender"
-    description: "Gender identity"
+    description: "Self-identified gender identity (modern/living persons)"
     vocabulary_type: gender_types
     temporal: true
-  
+
   occupation:
     label: "Occupation"
     description: "Profession or trade"

--- a/specification/5-standard-vocabularies/sex-types.glx
+++ b/specification/5-standard-vocabularies/sex-types.glx
@@ -1,0 +1,31 @@
+# Standard Sex Types
+# This file defines the standard sex types for GENEALOGIX archives.
+# Sex values represent what was recorded in source documents (e.g., GEDCOM SEX, census enumerations).
+# For self-identified gender identity, see gender-types.glx.
+# Archives can extend this with custom types by adding additional entries.
+# Each entry includes a GEDCOM SEX mapping for interoperability where applicable.
+
+sex_types:
+  male:
+    label: "Male"
+    description: "Recorded as male in source documents"
+    gedcom: "M"
+
+  female:
+    label: "Female"
+    description: "Recorded as female in source documents"
+    gedcom: "F"
+
+  unknown:
+    label: "Unknown"
+    description: "Source was consulted but sex could not be determined"
+    gedcom: "U"
+
+  not_recorded:
+    label: "Not Recorded"
+    description: "Source does not contain a sex/gender field"
+
+  other:
+    label: "Other"
+    description: "Recorded value outside the male/female/unknown categories"
+    gedcom: "X"

--- a/specification/schema/v1/embed.go
+++ b/specification/schema/v1/embed.go
@@ -60,6 +60,11 @@ var MediaTypesSchema []byte
 //go:embed vocabularies/confidence-levels.schema.json
 var ConfidenceLevelsSchema []byte
 
+// SexTypesSchema contains the embedded sex-types vocabulary schema.
+//
+//go:embed vocabularies/sex-types.schema.json
+var SexTypesSchema []byte
+
 // GenderTypesSchema contains the embedded gender-types vocabulary schema.
 //
 //go:embed vocabularies/gender-types.schema.json

--- a/specification/schema/v1/glx-file.schema.json
+++ b/specification/schema/v1/glx-file.schema.json
@@ -170,9 +170,17 @@
       },
       "additionalProperties": false
     },
+    "sex_types": {
+      "type": "object",
+      "description": "Sex type vocabulary (as recorded in source documents)",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": { "$ref": "vocabularies/sex-types.schema.json" }
+      },
+      "additionalProperties": false
+    },
     "gender_types": {
       "type": "object",
-      "description": "Gender type vocabulary",
+      "description": "Gender identity vocabulary",
       "patternProperties": {
         "^[a-zA-Z0-9_-]+$": { "$ref": "vocabularies/gender-types.schema.json" }
       },

--- a/specification/schema/v1/vocabularies/gender-types.schema.json
+++ b/specification/schema/v1/vocabularies/gender-types.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/genealogix/glx/main/specification/schema/v1/vocabularies/gender-types.schema.json",
   "title": "Gender Types Vocabulary",
-  "description": "Defines the standard and custom gender types available for person entities",
+  "description": "Defines the standard and custom gender identity types for the person `gender` property (self-identified gender identity, primarily for modern/living persons)",
   "type": "object",
   "required": ["gender_types"],
   "properties": {
@@ -18,21 +18,21 @@
   "definitions": {
     "GenderTypeDefinition": {
       "type": "object",
-      "description": "Definition of a single gender type",
+      "description": "Definition of a single gender identity type",
       "required": ["label"],
       "properties": {
         "label": {
           "type": "string",
           "minLength": 1,
-          "description": "Human-readable label for the gender type"
+          "description": "Human-readable label for the gender identity"
         },
         "description": {
           "type": "string",
-          "description": "Detailed description of the gender type"
+          "description": "Detailed description of the gender identity"
         },
         "gedcom": {
           "type": "string",
-          "description": "Corresponding GEDCOM SEX value for interoperability"
+          "description": "Optional GEDCOM value; GEDCOM has no standard tag for gender identity and defers to FACT"
         }
       }
     }

--- a/specification/schema/v1/vocabularies/sex-types.schema.json
+++ b/specification/schema/v1/vocabularies/sex-types.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/genealogix/glx/main/specification/schema/v1/vocabularies/sex-types.schema.json",
+  "title": "Sex Types Vocabulary",
+  "description": "Defines the standard and custom sex types available for the person `sex` property (as recorded in source documents)",
+  "type": "object",
+  "required": ["sex_types"],
+  "properties": {
+    "sex_types": {
+      "type": "object",
+      "description": "Map of sex type definitions",
+      "additionalProperties": {
+        "$ref": "#/definitions/SexTypeDefinition"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "SexTypeDefinition": {
+      "type": "object",
+      "description": "Definition of a single sex type",
+      "required": ["label"],
+      "properties": {
+        "label": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable label for the sex type"
+        },
+        "description": {
+          "type": "string",
+          "description": "Detailed description of the sex type"
+        },
+        "gedcom": {
+          "type": "string",
+          "description": "Corresponding GEDCOM SEX value for interoperability"
+        }
+      }
+    }
+  }
+}

--- a/website/.vitepress/data/vocabularies.data.js
+++ b/website/.vitepress/data/vocabularies.data.js
@@ -32,6 +32,7 @@ export default {
         'utf-8'
       ),
       'repository-types': readFileSync(resolve(vocabDir, 'repository-types.glx'), 'utf-8'),
+      'sex-types': readFileSync(resolve(vocabDir, 'sex-types.glx'), 'utf-8'),
       'source-properties': readFileSync(resolve(vocabDir, 'source-properties.glx'), 'utf-8'),
       'source-types': readFileSync(resolve(vocabDir, 'source-types.glx'), 'utf-8')
     }

--- a/website/standard-vocabularies.md
+++ b/website/standard-vocabularies.md
@@ -85,7 +85,7 @@ Defines additional properties that can be associated with relationships (like cu
 
 ### Person Properties
 
-Defines properties that can be associated with people (such as gender, physical characteristics, titles).
+Defines properties that can be associated with people (such as sex, gender, physical characteristics, titles).
 
 <YamlFile
   :content="vocabularies['person-properties']"
@@ -197,6 +197,32 @@ Defines confidence levels for assertions, representing researcher certainty in c
 />
 
 **See Also:** [Assertion Entity Documentation](/specification/4-entity-types/assertion) | [Vocabularies Specification](/specification/4-entity-types/vocabularies#confidence-levels-vocabulary)
+
+---
+
+### Sex Types
+
+Defines controlled values for the `sex` person property (male, female, unknown, not_recorded, other). Sex is what was recorded in source documents (e.g., GEDCOM SEX, census enumerations) and maps to GEDCOM `SEX` on import/export.
+
+<YamlFile
+  :content="vocabularies['sex-types']"
+  title="vocabularies/sex-types.glx"
+/>
+
+**See Also:** [Person Entity Documentation](/specification/4-entity-types/person) | [Vocabularies Specification](/specification/4-entity-types/vocabularies#property-definition-structure)
+
+---
+
+### Gender Types
+
+Defines controlled values for the `gender` person property — self-identified gender identity (male, female, nonbinary, other). Primarily relevant for modern records and living persons.
+
+<YamlFile
+  :content="vocabularies['gender-types']"
+  title="vocabularies/gender-types.glx"
+/>
+
+**See Also:** [Person Entity Documentation](/specification/4-entity-types/person) | [Vocabularies Specification](/specification/4-entity-types/vocabularies#property-definition-structure)
 
 ---
 


### PR DESCRIPTION
## What and why

Implements the two-field model proposed in #528. The existing `gender` person property conflated "sex as recorded in source documents" (GEDCOM `SEX`) with "self-identified gender identity". This PR splits them per Noah's proposal in [#528 (comment)](https://github.com/genealogix/glx/issues/528#issuecomment-4167165040):

- **`sex`** — maps to GEDCOM `SEX`. New `sex_types` vocabulary: `male`, `female`, `unknown`, `not_recorded`, `other`.
- **`gender`** — self-identified identity. `gender_types` now holds: `male`, `female`, `nonbinary`, `other`. No direct GEDCOM mapping (GEDCOM 7.0 defers to `FACT`).

A 1790 census recording "M" is documenting recorded sex, not making a statement about gender identity. GLX's evidence-first philosophy requires representing what the source actually says.

### Key changes

**Specification**
- New `specification/5-standard-vocabularies/sex-types.glx` + JSON schema.
- `gender-types.glx` rewritten as the identity vocabulary; added `not_recorded` distinct from `unknown` to `sex_types`.
- `person-properties.glx` renames `gender` → `sex`, adds new `gender` entry.
- `glx-file.schema.json` adds top-level `sex_types` key.

**Go library**
- New `SexType` struct and `SexTypes` field on `GLXFile`; `constants.go` introduces `SexMale/Female/Unknown/NotRecorded/Other` and identity `GenderMale/Female/Nonbinary/Other` constants.
- `mapGEDCOMSex` writes to `PersonPropertySex`; `mapSexToGEDCOM` prefers `sex_types` then falls back to `gender_types`.
- `assignHusbandWife` + census now read `sex`.

**CLI**
- `personSex()` helper unifies the "prefer sex, fall back to legacy gender" pattern across `vitals`, `summary`, etc.
- New opt-in **`glx migrate --rename-gender-to-sex`** flag that renames legacy `gender` properties, assertions, and inlined pre-split vocabularies to `sex`.

**Examples & tests**
- All example archives and testdata updated to `sex:`.
- New unit tests for the gender→sex migrator (rename, conflict warning, pre-split vocab rewrite, idempotency).
- New validation test confirming the standard vocabularies accept `sex: not_recorded` and `gender: nonbinary` without warnings.

## Related issues

Resolves #528. Closes #518, #534, #545.

## Testing

- `make test` — all Go tests pass (go-glx + glx).
- `node specification/validate-schemas.mjs` — all schemas valid.
- `glx validate` on every archive in `docs/examples/` — all valid.
- End-to-end import: Shakespeare GEDCOM → `properties.sex: male` on each person; `glx vitals` shows "Sex: male".
- End-to-end migrate: copy `complete-family` example, `sed` rename `sex:` → `gender:`, run `glx migrate <archive> --rename-gender-to-sex` → reports 3 property renames, `glx validate` clean afterward.
- Migrator tests cover: property rename, assertion rename, vocab-entry rename, pre-split `gender_types` → `sex_types` moves, conflict (both properties present) warning, no-op on post-split archives, no-op when flag not passed.

## Breaking changes

Yes — pre-v1.0 spec split.

- Archives using `gender: "male"` / `"female"` / `"other"` still validate (those values exist in both the new `gender_types` and `sex_types` vocabularies), but semantically they should be renamed to `sex:`.
- Archives using `gender: "unknown"` produce an out-of-vocabulary warning (the new `gender_types` has no `unknown`; it now lives in `sex_types`).
- CLI readers (`vitals`, `summary`, `getPersonSex` on export) fall back to the legacy `gender` property, so existing archives keep working until migrated.

**Migration path:** `glx migrate <archive> --rename-gender-to-sex` renames legacy `gender` properties, matching assertions, and pre-split inlined `gender_types` vocabularies to the new `sex_types` naming. Opt-in; default migrate behavior is unchanged.