### PR TITLE
fix: Bump transitive postcss to 8.5.12 to clear npm audit

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2621,9 +2621,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
<!--
  PR title must follow conventional commits: type: Description
-->

## What and why

`npm audit` has been failing on every PR that touches `/website` (and on any PR run that pulls a fresh `npm ci` against the website lockfile) due to a moderate-severity advisory against `postcss`:

- **Advisory**: [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) — PostCSS XSS via unescaped `</style>` in CSS Stringify output
- **Vulnerable**: `postcss <8.5.10`
- **Resolved version on `main`**: `8.5.8` (transitive via `vitepress`)

This bumps the transitive resolution to `postcss@8.5.12` by running `npm audit fix` in `/website`. Lockfile-only — no `package.json` changes, no direct-dependency upgrades.

After this lands, the failing `npm Audit` job on open PRs (#671, #711, #747) will go green on rebase.

## Related issues

None.

## Testing

- `cd website && npm ci && npm audit --audit-level=moderate` — `found 0 vulnerabilities`
- Diff is 3 lines: `version`, `resolved`, `integrity` of the `node_modules/postcss` entry in `website/package-lock.json`

## Breaking changes

None. PostCSS 8.5.x is patch-level; the bump is within the existing `^8.x` peer constraints expressed by `vitepress` and friends.
