### PR TITLE
ci: Add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,57 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Run weekly on Monday at 06:00 UTC (matches security.yml)
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GIT_CONFIG_COUNT: 2
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+  GIT_CONFIG_KEY_1: advice.detachedHead
+  GIT_CONFIG_VALUE_1: "false"
+
+jobs:
+  scorecard:
+    name: Scorecard Analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      security-events: write
+      id-token: write   # OIDC for publish_results
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-results
+          path: scorecard-results.sarif
+          retention-days: 5
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: scorecard-results.sarif
+          category: scorecard

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -30,6 +30,7 @@ jobs:
       security-events: write
       id-token: write   # OIDC for publish_results
       contents: read
+      actions: read     # workflow YAML analysis (Token-Permissions, Pinned-Dependencies)
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## What and why

The repo runs individual security checks (`govulncheck`, `gosec`, `dependency-review`, `npm audit`) but has no aggregate score across the 18+ supply-chain-security dimensions tracked by [OpenSSF Scorecard](https://securityscorecards.dev/) (branch protection, pinned dependencies, signed releases, token permissions, etc.).

This PR adds `.github/workflows/scorecard.yml` to:

- run the OpenSSF Scorecard analysis on push to `main`, weekly (Mon 06:00 UTC, same slot as `security.yml`), and on `workflow_dispatch`
- upload SARIF results to GitHub Code Scanning (visible under `Security → Code scanning → tool: scorecard`)
- publish to the public OpenSSF Scorecard API for the project badge / score viewer at `https://scorecard.dev/viewer/?uri=github.com/genealogix/glx`

Out of scope (deliberately):

- README badge — tracked by #464; the badge URL only resolves after the workflow has run on `main` at least once
- SHA-pinning all actions — tracked by #254
- `SCORECARD_TOKEN` PAT for Branch-Protection / Webhooks checks — can be added later if those checks score "?"

## Related issues

Resolves #349.

## Testing

- `actionlint .github/workflows/scorecard.yml` → clean (exit 0).
- YAML parses (`python -c "import yaml; yaml.safe_load(open('.github/workflows/scorecard.yml'))"`).
- The workflow only triggers on push to `main` / weekly schedule / `workflow_dispatch`, so it will **not** run against this PR. After merge, the next push to `main` will surface results in the Security tab.

## Breaking changes

None.
