### PR TITLE
fix: Use place hierarchy in assertion-workflow example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Fixed
 
+#### Documentation
+
+- **`assertion-workflow` example uses flat `jurisdiction` strings instead of place hierarchy** — `docs/examples/assertion-workflow/archive.glx` defined `place-boston`, `place-new-york`, and `place-cambridge` with a `jurisdiction: "Massachusetts, United States"` property string instead of the `parent:` chain documented in `specification/4-entity-types/place.md`. The example now adds `place-united-states`, `place-massachusetts`, and `place-new-york-state` and links the cities via `parent:`, matching the canonical pattern in `complete-family`. Closes #574
+
 #### CLI
 
 - **`personSex` / `displayableGenderIdentity` / `pronounFor` handle temporal shapes** — `sex` and `gender` are both declared `temporal: true` in `person-properties`, so archives may store them as `{value, date}` maps or `[{value, date}, ...]` lists. Previously the CLI ran these through `propertyString`, which `fmt.Sprint`-ed non-string values and produced useless display strings like `map[date:1850 value:male]` — also breaking the legacy-gender fallback, the identity-vs-duplicate predicate, and pronoun selection (every temporal value silently fell through to they/their). A new `propertyScalar` helper extracts the canonical scalar from string / single-map / list shapes. (PR #742)

--- a/docs/examples/assertion-workflow/archive.glx
+++ b/docs/examples/assertion-workflow/archive.glx
@@ -8,23 +8,34 @@
 # ===========================================================================
 
 places:
+  place-united-states:
+    name: "United States"
+    type: country
+
+  place-massachusetts:
+    name: "Massachusetts"
+    type: state
+    parent: place-united-states
+
+  place-new-york-state:
+    name: "New York"
+    type: state
+    parent: place-united-states
+
   place-boston:
     name: "Boston"
     type: city
-    properties:
-      jurisdiction: "Massachusetts, United States"
+    parent: place-massachusetts
 
   place-new-york:
     name: "New York"
     type: city
-    properties:
-      jurisdiction: "New York, United States"
+    parent: place-new-york-state
 
   place-cambridge:
     name: "Cambridge"
     type: city
-    properties:
-      jurisdiction: "Massachusetts, United States"
+    parent: place-massachusetts
 
 # ===========================================================================
 # APPROACH 1: DIRECT PROPERTY SETTING (Quick Data Entry)


### PR DESCRIPTION
## What and why

The `assertion-workflow` example in `docs/examples/` is one of the first concrete archives new users see. Its `archive.glx` defined three places (`place-boston`, `place-new-york`, `place-cambridge`) with a flat `jurisdiction: "Massachusetts, United States"` property string instead of the `parent:` chain documented in the Place entity spec (`specification/4-entity-types/place.md`). The sibling `complete-family` example correctly uses the hierarchy via `place-england` → `place-yorkshire` → `place-leeds`.

This change replaces the flat-jurisdiction shape with a hierarchical chain — adding `place-united-states`, `place-massachusetts`, and `place-new-york-state`, and linking each city via `parent:` — so the first example new users encounter teaches the canonical pattern that `glx places` hierarchy traversal depends on.

City entity IDs (`place-boston`, `place-new-york`, `place-cambridge`) are preserved, so all 11 references from events, assertions, and person `residence` properties continue to resolve unchanged.

## Related issues

Closes #574

## Testing

- `node specification/validate-schemas.mjs` — schemas valid
- `./bin/glx validate docs/examples/assertion-workflow/` — `Validated 15 files. Archive is valid.`
- `go test ./go-glx/ -run ExampleArchives` — `PASS` (round-trip test for `assertion-workflow` and the other six example archives)
- `./bin/glx places docs/examples/assertion-workflow/` — now resolves full hierarchical paths (e.g. `Boston, Massachusetts, United States`) and correctly flags `New York` as ambiguous between the city and the state, demonstrating the hierarchy traversal at work

## Breaking changes

None — this is a docs-only change to an example archive. No code, schema, or wire-format changes.
