### PR TITLE
test: Pin value_type enforcement on temporal properties (#668)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 #### Tests
 
 - **Round-trip validation tests for example archives** — `go-glx/example_archives_roundtrip_test.go` walks every archive under `docs/examples/` (single-file or multi-file), runs it through deserialize → re-serialize, validates each entity in the re-emitted output against its per-entity JSON schema (`person.schema.json`, `event.schema.json`, etc.), and asserts that the parsed-input YAML map equals the parsed-output map. The map-level comparison catches `omitempty` drops that struct equality cannot detect. (#296)
+- **Regression tests pinning `value_type` enforcement on temporal properties** — `go-glx/validation_temporal_test.go` now covers all three temporal-value shapes (simple value, single `{value, date}` object, list of objects) for properties declaring `value_type: integer`, asserting a warning is emitted when the value's runtime type doesn't match. Locks in behavior already implemented in `validateTemporalItem`. Closes #668.
 
 ### Changed
 

--- a/go-glx/validation_temporal_test.go
+++ b/go-glx/validation_temporal_test.go
@@ -261,6 +261,120 @@ func TestValidatePropertyValue_TemporalValidList(t *testing.T) {
 	}
 }
 
+// Pin value_type enforcement on the simple-value temporal path. Regression test for #668.
+func TestValidatePropertyValue_TemporalSimpleValueTypeMismatch(t *testing.T) {
+	glx := &GLXFile{
+		Persons: map[string]*Person{
+			"person-1": {
+				Properties: map[string]any{
+					"birth_year": "not-a-number",
+				},
+			},
+		},
+	}
+
+	propDef := &PropertyDefinition{
+		Label:     "Birth Year",
+		ValueType: "integer",
+		Temporal:  new(true),
+	}
+
+	result := &ValidationResult{}
+	glx.validatePropertyValue("persons", "person-1", "birth_year", glx.Persons["person-1"].Properties["birth_year"], propDef, result)
+
+	if len(result.Errors) != 0 {
+		t.Errorf("Expected 0 errors, got %d: %v", len(result.Errors), result.Errors)
+	}
+	if len(result.Warnings) != 1 {
+		t.Fatalf("Expected 1 warning, got %d: %v", len(result.Warnings), result.Warnings)
+	}
+	if !strings.Contains(result.Warnings[0].Message, "expected integer value, got string") {
+		t.Errorf("Warning should report integer/string mismatch, got: %s", result.Warnings[0].Message)
+	}
+	if result.Warnings[0].Field != "properties.birth_year" {
+		t.Errorf("Warning field should be 'properties.birth_year', got: %s", result.Warnings[0].Field)
+	}
+}
+
+// Pin value_type enforcement on the single-object temporal path. Regression test for #668.
+func TestValidatePropertyValue_TemporalSingleObjectValueTypeMismatch(t *testing.T) {
+	glx := &GLXFile{
+		Persons: map[string]*Person{
+			"person-1": {
+				Properties: map[string]any{
+					"birth_year": map[string]any{
+						"value": "not-a-number",
+						"date":  "1850",
+					},
+				},
+			},
+		},
+	}
+
+	propDef := &PropertyDefinition{
+		Label:     "Birth Year",
+		ValueType: "integer",
+		Temporal:  new(true),
+	}
+
+	result := &ValidationResult{}
+	glx.validatePropertyValue("persons", "person-1", "birth_year", glx.Persons["person-1"].Properties["birth_year"], propDef, result)
+
+	if len(result.Errors) != 0 {
+		t.Errorf("Expected 0 errors, got %d: %v", len(result.Errors), result.Errors)
+	}
+	if len(result.Warnings) != 1 {
+		t.Fatalf("Expected 1 warning, got %d: %v", len(result.Warnings), result.Warnings)
+	}
+	if !strings.Contains(result.Warnings[0].Message, "expected integer value, got string") {
+		t.Errorf("Warning should report integer/string mismatch, got: %s", result.Warnings[0].Message)
+	}
+	if result.Warnings[0].Field != "properties.birth_year.value" {
+		t.Errorf("Warning field should be 'properties.birth_year.value', got: %s", result.Warnings[0].Field)
+	}
+}
+
+// Pin value_type enforcement on the list-of-objects temporal path. Mirrors the
+// exact YAML scenario from #668.
+func TestValidatePropertyValue_TemporalListItemValueTypeMismatch(t *testing.T) {
+	glx := &GLXFile{
+		Persons: map[string]*Person{
+			"person-1": {
+				Properties: map[string]any{
+					"birth_year": []any{
+						map[string]any{
+							"value": "not-a-number",
+							"date":  "1850",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	propDef := &PropertyDefinition{
+		Label:     "Birth Year",
+		ValueType: "integer",
+		Temporal:  new(true),
+	}
+
+	result := &ValidationResult{}
+	glx.validatePropertyValue("persons", "person-1", "birth_year", glx.Persons["person-1"].Properties["birth_year"], propDef, result)
+
+	if len(result.Errors) != 0 {
+		t.Errorf("Expected 0 errors, got %d: %v", len(result.Errors), result.Errors)
+	}
+	if len(result.Warnings) != 1 {
+		t.Fatalf("Expected 1 warning, got %d: %v", len(result.Warnings), result.Warnings)
+	}
+	if !strings.Contains(result.Warnings[0].Message, "expected integer value, got string") {
+		t.Errorf("Warning should report integer/string mismatch, got: %s", result.Warnings[0].Message)
+	}
+	if result.Warnings[0].Field != "properties.birth_year[0].value" {
+		t.Errorf("Warning field should be 'properties.birth_year[0].value', got: %s", result.Warnings[0].Field)
+	}
+}
+
 // --- Temporal consistency tests ---
 
 func TestValidateDeathBeforeBirth(t *testing.T) {


### PR DESCRIPTION
## What and why

Issue #668 reports that the validator does not type-check the `value` field of temporal property entries against the property's declared `value_type`, citing this scenario:

```yaml
birth_year:
  label: "Birth Year"
  value_type: integer
  temporal: true

# In a Person:
properties:
  birth_year:
    - value: "not-a-number"
      date: "1850"
```

**The validation already works.** Tracing the three temporal code paths in `validatePropertyValue` (`go-glx/validation.go:721`):

| Path | Trigger | validateValueType called? | Warning produced |
|------|---------|--------|------|
| Simple value | `birth_year: "not-a-number"` | yes — directly at validation.go:779 | `properties.birth_year` |
| Single object | `birth_year: {value: "...", date: "..."}` | yes — via `validateTemporalItem` at validation.go:884–885 | `properties.birth_year.value` |
| List of objects | `birth_year: [{value: "...", date: "..."}]` | yes — via `validateTemporalItem` at validation.go:884–885 | `properties.birth_year[0].value` |

`git blame` shows the check at `validation.go:884–885` has been in place since `fca705f` (v0.0.0-beta.2, Dec 7) — well before "beta 10 release prep" when the issue was filed. Most likely explanation: `/check-code-drift` did static schema-vs-validator scanning and didn't trace dispatch through `validateTemporalItem`, producing a false positive.

This PR adds three regression tests that pin the existing behavior on each temporal path so it can't silently regress. **No production code change.**

## Related issues

Closes #668

## Testing

- `go test -v -run TestValidatePropertyValue_Temporal ./go-glx/` — 8 tests pass (5 pre-existing + 3 new), all assert specific `Field` paths so failures localize to the broken code path.
- `go test -timeout 10m ./...` — passes the suites this PR touches. (Same pre-existing `TestSerializeMultiFileCrossTypeNoCollision` failure that reproduces on `main` and is unrelated; flagged in #762.)
- `golangci-lint run --new-from-rev=HEAD ./go-glx/...` — 0 new issues. Used `new(true)` (Go 1.26 syntax) instead of the file's existing `boolPtr(true)` because the lefthook lint flags new `boolPtr` usages via the `modernize` analyzer; existing `boolPtr` calls remain untouched.
- Reproduced the issue's exact YAML against `validatePropertyValue` on `main` before writing the tests; all three paths emitted `expected integer value, got string` as expected.

## Breaking changes

None — tests-only addition.
