### PR TITLE
docs: reference Genealogical Proof Standard in assertion-workflow README

### DIFF
--- a/docs/examples/assertion-workflow/README.md
+++ b/docs/examples/assertion-workflow/README.md
@@ -103,6 +103,8 @@ Repository → Source → Citation → Assertion → Property
 4. **Assertion**: `assertion-robert-birth` (claim that Robert was born March 22, 1955)
 5. **Event**: `event-robert-birth` with date `"1955-03-22"` and place `place-new-york`
 
+> **Why this matters:** The evidence chain supports the [Genealogical Proof Standard](https://www.bcgcertification.org/resources/standard.html) (GPS), which requires (1) reasonably exhaustive research, (2) complete source citations, (3) analysis of evidence, (4) resolution of conflicts, and (5) a soundly reasoned conclusion. GLX's assertion model provides the data structure for documenting all five elements. See [decision 0002](/decisions/0002-evidence-first-data-model) for the rationale.
+
 ## Recommended Workflow
 
 ### For Quick Data Entry

--- a/docs/examples/assertion-workflow/README.md
+++ b/docs/examples/assertion-workflow/README.md
@@ -103,7 +103,7 @@ Repository → Source → Citation → Assertion → Property
 4. **Assertion**: `assertion-robert-birth` (claim that Robert was born March 22, 1955)
 5. **Event**: `event-robert-birth` with date `"1955-03-22"` and place `place-new-york`
 
-> **Why this matters:** The evidence chain supports the [Genealogical Proof Standard](https://www.bcgcertification.org/resources/standard.html) (GPS), which requires (1) reasonably exhaustive research, (2) complete source citations, (3) analysis of evidence, (4) resolution of conflicts, and (5) a soundly reasoned conclusion. GLX's assertion model provides the data structure for documenting all five elements. See [decision 0002](/decisions/0002-evidence-first-data-model) for the rationale.
+> **Learn More:** The evidence chain supports the [Genealogical Proof Standard](https://www.bcgcertification.org/resources/standard.html) (GPS), which requires (1) reasonably exhaustive research, (2) complete source citations, (3) analysis of evidence, (4) resolution of conflicts, and (5) a soundly reasoned conclusion. GLX's assertion model provides the data structure for documenting all five elements. See [ADR-0002: Evidence-first data model](/decisions/0002-evidence-first-data-model) for the rationale.
 
 ## Recommended Workflow
 


### PR DESCRIPTION
## Summary

- Adds a brief `> **Learn More:**` callout at the end of "The Evidence Chain" section in `docs/examples/assertion-workflow/README.md`, naming the [Genealogical Proof Standard](https://www.bcgcertification.org/resources/standard.html) (GPS) — the methodology the chain is designed to support — and listing the five GPS elements that GLX's assertion model documents.
- Cross-links to [ADR-0002: Evidence-first data model](/decisions/0002-evidence-first-data-model) for the deeper rationale.
- Two-line insertion. No other lines touched.

## Why

The README explained the *mechanics* of the evidence chain (Repository → Source → Citation → Assertion) but never named the *standard* it implements. New readers now leave with both — and a path into ADR-0002 for the full "why."

## Conventions honored

- **URL**: `https://www.bcgcertification.org/resources/standard.html` matches existing GPS references in `CONTRIBUTING.md:240` and `docs/decisions/0002-evidence-first-data-model.md:22`.
- **Callout style**: `> **Learn More:** ...` matches the established pattern in `docs/examples/complete-family/README.md:100`.
- **Cross-link**: absolute VitePress route `/decisions/0002-evidence-first-data-model` matches the convention used elsewhere in this README (e.g. links to `/specification/...` at lines 255–256). Link text mirrors the sidebar entry in `website/.vitepress/config.js`.

## Test plan

- [x] `npx markdownlint-cli2 docs/examples/assertion-workflow/README.md` — 0 errors
- [x] `bash scripts/check-links.sh` — 337/337 relative links OK
- [x] Internal route `/decisions/0002-evidence-first-data-model` registered in `website/.vitepress/config.js` (sidebar + rewrites) — VitePress build will resolve
- [x] External URL already in lychee weekly check (no new external link introduced)
- [ ] CI markdownlint workflow passes
- [ ] CI check-links workflow passes
- [ ] CI lint workflow passes (if in scope for docs PRs)

Closes #572
