### PR TITLE
docs: Clarify source-properties.glx url vs citation url description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 - **`relationship-types.glx` GEDCOM mapping coverage documented** — Documented `step_parent`, `godparent`, `partner`, `guardian`, `neighbor`, `coworker`, `housemate`, `apprenticeship`, `employment`, `enslavement`, and `relative` as having no direct GEDCOM equivalent via inline comments, with rationale for `step_parent` (PEDI `sealed` is mapped to generic `parent_child` per `specification/4-entity-types/relationship.md` and `go-glx/gedcom_converter.go`), `godparent` (GEDCOM 7.0 `ASSO ROLE GODP` is consumed as a baptism event participant role, not a standalone relationship), and `partner` (`MARR TYPE` is collapsed into the `marriage` relationship plus a `marriage_type` event property by the importer). Closes #544.
 
+- **`source-properties.glx` clarified `url` vs citation `url`** — The previous description didn't distinguish the source-level URL (collection or database landing page) from the per-record citation URL, leaving readers looking for "where to put a permalink to a specific record" with no signal. The description now names the source-level intent and redirects record-specific URLs to the citation `url` property. Closes #560.
+
 #### go-glx
 
 - **Unified 9 vocabulary structs into a single `VocabularyEntry` type** — `EventType`, `ParticipantRole`, `ConfidenceLevel`, `RelationshipType`, `PlaceType`, `SourceType`, `RepositoryType`, `MediaType`, and `GenderType` have been replaced by one `VocabularyEntry` struct carrying the union of their optional fields (`GEDCOM`, `Category`, `MimeType`, `AppliesTo`). The YAML wire format (`.glx` files on disk) is unchanged; consumers of `*EventType` etc. must switch to `*VocabularyEntry`. Closes #504

--- a/specification/5-standard-vocabularies/source-properties.glx
+++ b/specification/5-standard-vocabularies/source-properties.glx
@@ -54,5 +54,5 @@ source_properties:
 
   url:
     label: "URL"
-    description: "Web address where the source can be accessed online (e.g., FamilySearch, Ancestry, FindAGrave)"
+    description: "Web address for the source collection or database. For URLs to specific records within the source, use the citation url property instead."
     value_type: string


### PR DESCRIPTION
## What and why

Issue #560 reports that the `url` property defined in `source-properties.glx` and the `url` property defined in `citation-properties.glx` have descriptions too similar to make their intended distinction obvious — source `url` is the collection/database landing page, citation `url` is a per-record permalink. The previous source description (`"Web address where the source can be accessed online (e.g., FamilySearch, Ancestry, FindAGrave)"`) gave readers no signal to put record-specific URLs on the citation property instead.

The description now reads:

> Web address for the source collection or database. For URLs to specific records within the source, use the citation url property instead.

— exactly the text prescribed by the issue. It both names the source-level intent (collection/database landing page) and explicitly redirects record-specific URLs to the citation `url` property.

## Related issues

Closes #560.

## Testing

- `node specification/validate-schemas.mjs` — all 29 schemas valid.
- `go test ./go-glx/... -run "Vocab|Source|Roundtrip|Example"` — pass. (Full `go test ./...` has one failing test, `TestSerializeMultiFileCrossTypeNoCollision`, verified pre-existing on `origin/main` and unrelated to this change.)
- `git diff` confirms the only changes are the single description line in `specification/5-standard-vocabularies/source-properties.glx` and one entry in `CHANGELOG.md` under `## [Unreleased]` → `### Changed`.

Following the precedent of PR #760 (closing #533), only the canonical `*-properties.glx` spec file was edited; downstream paraphrased summaries in `vocabularies.md`, `source.md`, the standard-vocabularies `README.md`, and `docs/examples/single-file/archive.glx` were left untouched (they already use shorter paraphrased forms, not verbatim copies of the old text).

## Breaking changes

None. Spec-text only — no schema, wire-format, GEDCOM mapping, or tooling change.
