### PR TITLE
ci: Add test coverage tracking and enforcement via Codecov (#259)

### DIFF
--- a/.github/workflows/validate-spec.yml
+++ b/.github/workflows/validate-spec.yml
@@ -102,9 +102,15 @@ jobs:
           # Run all tests for both CLI and core library packages
           # Includes slow/large file tests (habsburg.ged with 34,020 persons)
           # Capture stderr — fail if any "Warning:" lines are emitted
-          go test ./glx/... ./go-glx/... -v -timeout 15m 2> >(tee /tmp/test-stderr.log >&2)
+          go test ./glx/... ./go-glx/... -v -timeout 15m -coverprofile=coverage.out 2> >(tee /tmp/test-stderr.log >&2)
           if grep -qi "^Warning:" /tmp/test-stderr.log 2>/dev/null; then
             echo "::error::Tests emitted warnings on stderr — see log above"
             exit 1
           fi
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.out
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,6 +195,15 @@ make check-schemas     # Validate JSON schemas
 - GEDCOM test files: `glx/testdata/gedcom/`
 - Validation test fixtures: `glx/testdata/valid/` and `glx/testdata/invalid/`
 
+### Coverage
+
+CI uploads coverage to [Codecov](https://codecov.io/gh/genealogix/glx) on every PR and push to `main`. Two checks gate merges:
+
+- **Project coverage** must not drop more than 1% from the current baseline.
+- **Patch coverage** (lines changed by the PR) must be at least **80%** covered.
+
+Run `make test-coverage` locally to preview both numbers before pushing.
+
 ### CI Checks
 
 Every PR runs these checks automatically:
@@ -202,6 +211,7 @@ Every PR runs these checks automatically:
 | Check | What it does |
 |-------|--------------|
 | **Validate Specification / test-conformance** | Go tests for `glx/` and `go-glx/` packages |
+| **codecov/project**, **codecov/patch** | Coverage must not drop (project) and new code ≥80% covered (patch) |
 | **Validate Specification / validate-schemas** | JSON schema validation |
 | **Validate Specification / validate-examples** | All example archives pass `glx validate` |
 | **Lint Markdown / markdownlint-cli2** | Structural markdown validation for `specification/`, `docs/`, root `*.md` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,7 +202,7 @@ CI uploads coverage to [Codecov](https://codecov.io/gh/genealogix/glx) on every 
 - **Project coverage** must not drop more than 1% from the current baseline.
 - **Patch coverage** (lines changed by the PR) must be at least **80%** covered.
 
-Run `make test-coverage` locally to preview both numbers before pushing.
+Run `make test-coverage` locally to preview the total project coverage before pushing (the patch number is computed by Codecov from the PR diff and isn't reproducible locally).
 
 ### CI Checks
 
@@ -211,7 +211,7 @@ Every PR runs these checks automatically:
 | Check | What it does |
 |-------|--------------|
 | **Validate Specification / test-conformance** | Go tests for `glx/` and `go-glx/` packages |
-| **codecov/project**, **codecov/patch** | Coverage must not drop (project) and new code ≥80% covered (patch) |
+| **codecov/project**, **codecov/patch** | Project coverage may drop by at most 1%; patch coverage (new code) must be ≥80% |
 | **Validate Specification / validate-schemas** | JSON schema validation |
 | **Validate Specification / validate-examples** | All example archives pass `glx validate` |
 | **Lint Markdown / markdownlint-cli2** | Structural markdown validation for `specification/`, `docs/`, root `*.md` |

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ layout: doc
 [![Go Version](https://img.shields.io/github/go-mod/go-version/genealogix/glx)](https://github.com/genealogix/glx/blob/main/go.mod)
 [![License](https://img.shields.io/badge/license-Apache%202.0-green.svg)](https://github.com/genealogix/glx/blob/main/LICENSE)
 [![CI](https://github.com/genealogix/glx/workflows/Validate%20Specification/badge.svg)](https://github.com/genealogix/glx/actions)
+[![codecov](https://codecov.io/gh/genealogix/glx/branch/main/graph/badge.svg)](https://codecov.io/gh/genealogix/glx)
 [![Go Report Card](https://goreportcard.com/badge/github.com/genealogix/glx)](https://goreportcard.com/report/github.com/genealogix/glx)
 [![Contributors](https://img.shields.io/github/contributors/genealogix/glx.svg)](https://github.com/genealogix/glx/graphs/contributors)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+
+comment:
+  require_changes: true


### PR DESCRIPTION
## Summary

Closes #259.

Adds CI coverage instrumentation and enforcement via Codecov:

- `.github/workflows/validate-spec.yml`: `go test` in the `test-conformance` job now emits `coverage.out`; a new step uploads it via `codecov/codecov-action@v5`.
- `codecov.yml` (new): `project: target: auto` (block PRs that lower the baseline by more than 1%) + `patch: target: 80%` (lines changed by a PR must be ≥80% covered).
- `README.md`: Codecov badge next to the existing CI badge.
- `CONTRIBUTING.md`: short "Coverage" subsection under Testing + row in the CI Checks table.

## Note on the issue's premise

The issue says CLAUDE.md mandates 80% coverage. That isn't actually in CLAUDE.md (or CONTRIBUTING.md) on `main` — checked both. So this PR introduces the policy here rather than enforcing an existing one. If you'd like the threshold reflected in CLAUDE.md too, happy to follow up in a separate change.

## Design choices

- **Codecov over Coveralls** — more common in Go, the v5 action is well-maintained, and `codecov.yml` cleanly supports both project and patch thresholds.
- **`project: auto` (not `80%`)** — the literal "80% project" reading of the issue would turn CI red the moment baseline drifts below 80% on an unrelated PR. `auto` instead blocks *regressions* from whatever the current baseline is (measured locally at 83.1% on this branch), and the 80% policy applies to new code via the patch check. This is the Codecov-recommended config and matches the spirit of the issue without the "first PR breaks CI" failure mode.
- **No `-covermode=atomic`** — there's no `t.Parallel()` anywhere in the test suite, so the default `set` mode is correct and slightly faster.
- **Patch threshold is strict (80%, no tolerance).** A one-line bugfix in an untested file will fail the patch check. This is the literal reading of the issue; if it causes friction we can ratchet the tolerance up.

## Setup required after merge

The repo needs `CODECOV_TOKEN` added to repository secrets for reliable uploads from forked PRs (Codecov tightened tokenless support post-2023). Steps:

1. Sign in at https://app.codecov.io with the genealogix org's GitHub account.
2. Add the `glx` repo and copy the upload token.
3. Add it as `CODECOV_TOKEN` under **Settings → Secrets and variables → Actions**.

`fail_ci_if_error: false` ensures CI stays green if the token is unset or Codecov has an outage — coverage regressions still surface as failing Codecov status checks on the PR.

## Test plan

- [x] Local `make test-coverage` still works (baseline: 83.1%).
- [x] `yaml.safe_load` parses `validate-spec.yml` and `codecov.yml`.
- [ ] Confirm `test-conformance` job in CI uploads `coverage.out` cleanly (visible in the action's logs).
- [ ] Confirm Codecov status check appears on this PR within ~2 min of test completion.
- [ ] Confirm README badge renders the current % after merge (not "unknown").
