### PR TITLE
docs: Enhance basic-family example with events, places, and evidence chain (#576)

### DIFF
--- a/docs/examples/basic-family/README.md
+++ b/docs/examples/basic-family/README.md
@@ -1,13 +1,19 @@
 ---
 title: Basic Family Example
-description: Foundational GENEALOGIX archive with two-parent household and basic relationships
+description: Foundational GENEALOGIX archive with two-parent household, events, places, and a complete evidence chain
 layout: doc
 ---
 
 # Basic Family Example
 
-A foundational GENEALOGIX archive demonstrating a two-parent household
-with two children and basic relationship entries.
+A foundational GENEALOGIX archive demonstrating a two-parent household with
+two children, life events tied to dated places, and a minimal evidence chain
+from repository to assertion.
+
+This is the second example in the learning path. It builds on
+[Minimal](../minimal/) by adding events, dates, places, and a single
+source-citation-assertion chain. [Complete Family](../complete-family/) takes
+the same pattern further with multiple sources, repositories, and assertions.
 
 ## Structure
 
@@ -22,35 +28,40 @@ basic-family/
 │   ├── rel-marriage.glx
 │   ├── rel-parent-alice.glx
 │   └── rel-parent-robert-jr.glx
+├── events/
+│   ├── event-births.glx
+│   └── event-marriage.glx
+├── places/
+│   ├── place-united-states.glx
+│   ├── place-illinois.glx
+│   └── place-springfield.glx
+├── repositories/
+│   └── repository-sangamon-county-courthouse.glx
+├── sources/
+│   └── source-sangamon-births.glx
+├── citations/
+│   └── citation-robert-birth.glx
+├── assertions/
+│   └── assertion-robert-birth-date.glx
 ├── vocabularies/           # Symlinks to standard vocabularies
 └── README.md
 ```
 
 ## Family Overview
 
-- Mary and Robert Thompson are married.
-- They have two children: Alice and Robert Jr.
-- Relationships demonstrate marriage and parent-child connections.
+- **Robert Thompson** (born April 12, 1850, Springfield, IL)
+- **Mary Thompson** (born August 30, 1852, Springfield, IL)
+- Robert and Mary marry on June 15, 1875, in Springfield.
+- **Alice Thompson** (born March 22, 1878, Springfield, IL)
+- **Robert Thompson Jr.** (born November 5, 1881, Springfield, IL)
 
-## Files
+Robert's birth date is backed by a citation to the Sangamon County civil
+birth register, demonstrating the full evidence chain.
 
-### persons/person-mary-thompson.glx
-
-```yaml
-persons:
-  person-mary-thompson:
-    properties:
-      name:
-        value: "Mary Thompson"
-        fields:
-          given: "Mary"
-          surname: "Thompson"
-      sex: female
-```
-
-### persons/person-robert-thompson.glx
+## Persons
 
 ```yaml
+# persons/person-robert-thompson.glx
 persons:
   person-robert-thompson:
     properties:
@@ -59,41 +70,16 @@ persons:
         fields:
           given: "Robert"
           surname: "Thompson"
-      sex: male
+      sex: "male"
 ```
 
-### persons/person-alice-thompson.glx
+The other three person files follow the same pattern. Dates and places are
+recorded on events, not directly on persons.
+
+## Relationships
 
 ```yaml
-persons:
-  person-alice-thompson:
-    properties:
-      name:
-        value: "Alice Thompson"
-        fields:
-          given: "Alice"
-          surname: "Thompson"
-      sex: female
-```
-
-### persons/person-robert-thompson-jr.glx
-
-```yaml
-persons:
-  person-robert-thompson-jr:
-    properties:
-      name:
-        value: "Robert Thompson Jr."
-        fields:
-          given: "Robert"
-          surname: "Thompson"
-          suffix: "Jr."
-      sex: male
-```
-
-### relationships/rel-marriage.glx
-
-```yaml
+# relationships/rel-marriage.glx
 relationships:
   rel-marriage:
     type: marriage
@@ -102,37 +88,113 @@ relationships:
         role: spouse
       - person: person-robert-thompson
         role: spouse
+    start_event: event-marriage-1875
 ```
 
-### relationships/rel-parent-alice.glx
+The two parent-child relationships connect each child to both parents.
+
+## Events
 
 ```yaml
-relationships:
-  rel-parent-alice:
-    type: parent_child
+# events/event-marriage.glx
+events:
+  event-marriage-1875:
+    title: "Thompson Wedding"
+    type: marriage
+    date: "1875-06-15"
+    place: place-springfield
     participants:
-      - person: person-mary-thompson
-        role: parent
       - person: person-robert-thompson
-        role: parent
-      - person: person-alice-thompson
-        role: child
+        role: groom
+      - person: person-mary-thompson
+        role: bride
+    properties:
+      description: "Marriage of Robert Thompson and Mary Thompson in Springfield, Illinois"
 ```
 
-### relationships/rel-parent-robert-jr.glx
+`events/event-births.glx` contains four `type: birth` events — one for each
+family member — each referencing `place-springfield`.
+
+## Places
+
+Places nest hierarchically via the `parent` field, so a single change to
+`place-illinois` propagates to every entity that references it.
 
 ```yaml
-relationships:
-  rel-parent-robert-jr:
-    type: parent_child
-    participants:
-      - person: person-mary-thompson
-        role: parent
-      - person: person-robert-thompson
-        role: parent
-      - person: person-robert-thompson-jr
-        role: child
+# places/place-springfield.glx
+places:
+  place-springfield:
+    name: "Springfield"
+    type: city
+    parent: place-illinois
+    latitude: 39.7817
+    longitude: -89.6501
+    notes: "Capital of Illinois, seat of Sangamon County"
 ```
+
+`place-illinois` has `parent: place-united-states`. `place-united-states`
+has no parent — it sits at the top of the hierarchy.
+
+## Evidence Chain
+
+This example demonstrates the four-entity evidence chain for a single fact —
+Robert Thompson's birth date:
+
+**Repository → Source → Citation → Assertion**
+
+```yaml
+# repositories/repository-sangamon-county-courthouse.glx
+repositories:
+  repository-sangamon-county-courthouse:
+    name: "Sangamon County Courthouse - County Clerk"
+    type: registry
+    address: "200 South Ninth Street, Springfield, IL 62701"
+    website: "https://www.sangamonil.gov/Departments/County-Clerk"
+    notes: "Civil records repository for Sangamon County, Illinois, including birth and marriage registers"
+```
+
+```yaml
+# sources/source-sangamon-births.glx
+sources:
+  source-sangamon-births:
+    title: "Sangamon County, Illinois - Register of Births"
+    type: vital_record
+    repository: repository-sangamon-county-courthouse
+    date: "FROM 1850 TO 1900"
+    description: "Civil birth register maintained by the Sangamon County Clerk"
+```
+
+```yaml
+# citations/citation-robert-birth.glx
+citations:
+  citation-robert-birth:
+    source: source-sangamon-births
+    properties:
+      locator: "Volume 1, Page 47, Entry 312"
+      text_from_source: "Robert Thompson, male, born April 12, 1850, Springfield"
+    notes: "Primary source - civil birth register"
+```
+
+```yaml
+# assertions/assertion-robert-birth-date.glx
+assertions:
+  assertion-robert-birth-date:
+    subject:
+      event: event-birth-robert
+    property: date
+    value: "1850-04-12"
+    citations:
+      - citation-robert-birth
+    confidence: high
+    status: proven
+    notes: "Birth date confirmed by the Sangamon County civil birth register"
+```
+
+The other birth dates and the marriage date are recorded directly on their
+events without supporting assertions — a common pattern when only one fact in
+an archive has been formally evidenced yet. See
+[Complete Family](../complete-family/) for an example with multiple
+assertions, multiple sources, and conflicting evidence.
 
 ## Validation
 
@@ -143,11 +205,17 @@ glx validate
 
 ## What This Demonstrates
 
-- Marriage and parent-child relationship entries
-- Multiple persons with cross-referenced relationships
-- Layout ready for adding sources, media, and assertions
+- **Persons and relationships** in a nuclear family
+- **Events** with dates, places, and typed participant roles
+- **Hierarchical places** via `parent` references (city → state → country)
+- **The full evidence chain** — repository, source, citation, assertion — for one fact
+- **Direct properties vs. assertions** — most dates here are direct on events; one is backed by an assertion
+- **Cross-references** between entities resolved at validation time
+- **Standard vocabularies** for event types, place types, source types, etc.
 
 ## Next Steps
 
-Add supporting sources (certificates, census records) under `sources/`
-and attach them to relationship or person assertion files.
+- See [Complete Family](../complete-family/) for multiple assertions per
+  subject, multiple sources, and a richer evidence web.
+- See [Assertion Workflow](../assertion-workflow/) for direct properties vs.
+  assertion-backed properties and how to iteratively raise confidence.

--- a/docs/examples/basic-family/assertions/assertion-robert-birth-date.glx
+++ b/docs/examples/basic-family/assertions/assertion-robert-birth-date.glx
@@ -1,0 +1,11 @@
+assertions:
+  assertion-robert-birth-date:
+    subject:
+      event: event-birth-robert
+    property: date
+    value: "1850-04-12"
+    citations:
+      - citation-robert-birth
+    confidence: high
+    status: proven
+    notes: "Birth date confirmed by the Sangamon County civil birth register"

--- a/docs/examples/basic-family/citations/citation-robert-birth.glx
+++ b/docs/examples/basic-family/citations/citation-robert-birth.glx
@@ -1,0 +1,7 @@
+citations:
+  citation-robert-birth:
+    source: source-sangamon-births
+    properties:
+      locator: "Volume 1, Page 47, Entry 312"
+      text_from_source: "Robert Thompson, male, born April 12, 1850, Springfield"
+    notes: "Primary source - civil birth register"

--- a/docs/examples/basic-family/events/event-births.glx
+++ b/docs/examples/basic-family/events/event-births.glx
@@ -1,0 +1,40 @@
+events:
+  event-birth-robert:
+    type: birth
+    date: "1850-04-12"
+    place: place-springfield
+    participants:
+      - person: person-robert-thompson
+        role: subject
+    properties:
+      description: "Birth of Robert Thompson in Springfield, Illinois"
+
+  event-birth-mary:
+    type: birth
+    date: "1852-08-30"
+    place: place-springfield
+    participants:
+      - person: person-mary-thompson
+        role: subject
+    properties:
+      description: "Birth of Mary Thompson in Springfield, Illinois"
+
+  event-birth-alice:
+    type: birth
+    date: "1878-03-22"
+    place: place-springfield
+    participants:
+      - person: person-alice-thompson
+        role: subject
+    properties:
+      description: "Birth of Alice Thompson in Springfield, Illinois"
+
+  event-birth-robert-jr:
+    type: birth
+    date: "1881-11-05"
+    place: place-springfield
+    participants:
+      - person: person-robert-thompson-jr
+        role: subject
+    properties:
+      description: "Birth of Robert Thompson Jr. in Springfield, Illinois"

--- a/docs/examples/basic-family/events/event-marriage.glx
+++ b/docs/examples/basic-family/events/event-marriage.glx
@@ -1,0 +1,13 @@
+events:
+  event-marriage-1875:
+    title: "Thompson Wedding"
+    type: marriage
+    date: "1875-06-15"
+    place: place-springfield
+    participants:
+      - person: person-robert-thompson
+        role: groom
+      - person: person-mary-thompson
+        role: bride
+    properties:
+      description: "Marriage of Robert Thompson and Mary Thompson in Springfield, Illinois"

--- a/docs/examples/basic-family/persons/person-alice-thompson.glx
+++ b/docs/examples/basic-family/persons/person-alice-thompson.glx
@@ -6,4 +6,4 @@ persons:
         fields:
           given: "Alice"
           surname: "Thompson"
-      sex: female
+      sex: "female"

--- a/docs/examples/basic-family/persons/person-mary-thompson.glx
+++ b/docs/examples/basic-family/persons/person-mary-thompson.glx
@@ -6,4 +6,4 @@ persons:
         fields:
           given: "Mary"
           surname: "Thompson"
-      sex: female
+      sex: "female"

--- a/docs/examples/basic-family/persons/person-robert-thompson-jr.glx
+++ b/docs/examples/basic-family/persons/person-robert-thompson-jr.glx
@@ -7,4 +7,4 @@ persons:
           given: "Robert"
           surname: "Thompson"
           suffix: "Jr."
-      sex: male
+      sex: "male"

--- a/docs/examples/basic-family/persons/person-robert-thompson.glx
+++ b/docs/examples/basic-family/persons/person-robert-thompson.glx
@@ -6,4 +6,4 @@ persons:
         fields:
           given: "Robert"
           surname: "Thompson"
-      sex: male
+      sex: "male"

--- a/docs/examples/basic-family/places/place-illinois.glx
+++ b/docs/examples/basic-family/places/place-illinois.glx
@@ -1,0 +1,8 @@
+places:
+  place-illinois:
+    name: "Illinois"
+    type: state
+    parent: place-united-states
+    latitude: 40.0417
+    longitude: -89.1965
+    notes: "Midwestern U.S. state, admitted 1818"

--- a/docs/examples/basic-family/places/place-springfield.glx
+++ b/docs/examples/basic-family/places/place-springfield.glx
@@ -1,0 +1,8 @@
+places:
+  place-springfield:
+    name: "Springfield"
+    type: city
+    parent: place-illinois
+    latitude: 39.7817
+    longitude: -89.6501
+    notes: "Capital of Illinois, seat of Sangamon County"

--- a/docs/examples/basic-family/places/place-united-states.glx
+++ b/docs/examples/basic-family/places/place-united-states.glx
@@ -1,0 +1,7 @@
+places:
+  place-united-states:
+    name: "United States"
+    type: country
+    latitude: 39.8283
+    longitude: -98.5795
+    notes: "Country in North America"

--- a/docs/examples/basic-family/relationships/rel-marriage.glx
+++ b/docs/examples/basic-family/relationships/rel-marriage.glx
@@ -6,3 +6,4 @@ relationships:
         role: spouse
       - person: person-robert-thompson
         role: spouse
+    start_event: event-marriage-1875

--- a/docs/examples/basic-family/repositories/repository-sangamon-county-courthouse.glx
+++ b/docs/examples/basic-family/repositories/repository-sangamon-county-courthouse.glx
@@ -1,0 +1,7 @@
+repositories:
+  repository-sangamon-county-courthouse:
+    name: "Sangamon County Courthouse - County Clerk"
+    type: registry
+    address: "200 South Ninth Street, Springfield, IL 62701"
+    website: "https://www.sangamonil.gov/Departments/County-Clerk"
+    notes: "Civil records repository for Sangamon County, Illinois, including birth and marriage registers"

--- a/docs/examples/basic-family/sources/source-sangamon-births.glx
+++ b/docs/examples/basic-family/sources/source-sangamon-births.glx
@@ -1,0 +1,7 @@
+sources:
+  source-sangamon-births:
+    title: "Sangamon County, Illinois - Register of Births"
+    type: vital_record
+    repository: repository-sangamon-county-courthouse
+    date: "FROM 1850 TO 1900"
+    description: "Civil birth register maintained by the Sangamon County Clerk"

--- a/docs/examples/basic-family/vocabularies/citation-properties.glx
+++ b/docs/examples/basic-family/vocabularies/citation-properties.glx
@@ -1,0 +1,1 @@
+../../../../specification/5-standard-vocabularies/citation-properties.glx

--- a/docs/examples/basic-family/vocabularies/confidence-levels.glx
+++ b/docs/examples/basic-family/vocabularies/confidence-levels.glx
@@ -1,0 +1,1 @@
+../../../../specification/5-standard-vocabularies/confidence-levels.glx

--- a/docs/examples/basic-family/vocabularies/event-properties.glx
+++ b/docs/examples/basic-family/vocabularies/event-properties.glx
@@ -1,0 +1,1 @@
+../../../../specification/5-standard-vocabularies/event-properties.glx

--- a/docs/examples/basic-family/vocabularies/event-types.glx
+++ b/docs/examples/basic-family/vocabularies/event-types.glx
@@ -1,0 +1,1 @@
+../../../../specification/5-standard-vocabularies/event-types.glx

--- a/docs/examples/basic-family/vocabularies/media-properties.glx
+++ b/docs/examples/basic-family/vocabularies/media-properties.glx
@@ -1,0 +1,1 @@
+../../../../specification/5-standard-vocabularies/media-properties.glx

--- a/docs/examples/basic-family/vocabularies/media-types.glx
+++ b/docs/examples/basic-family/vocabularies/media-types.glx
@@ -1,0 +1,1 @@
+../../../../specification/5-standard-vocabularies/media-types.glx

--- a/docs/examples/basic-family/vocabularies/place-properties.glx
+++ b/docs/examples/basic-family/vocabularies/place-properties.glx
@@ -1,0 +1,1 @@
+../../../../specification/5-standard-vocabularies/place-properties.glx

--- a/docs/examples/basic-family/vocabularies/place-types.glx
+++ b/docs/examples/basic-family/vocabularies/place-types.glx
@@ -1,0 +1,1 @@
+../../../../specification/5-standard-vocabularies/place-types.glx

--- a/docs/examples/basic-family/vocabularies/repository-properties.glx
+++ b/docs/examples/basic-family/vocabularies/repository-properties.glx
@@ -1,0 +1,1 @@
+../../../../specification/5-standard-vocabularies/repository-properties.glx

--- a/docs/examples/basic-family/vocabularies/repository-types.glx
+++ b/docs/examples/basic-family/vocabularies/repository-types.glx
@@ -1,0 +1,1 @@
+../../../../specification/5-standard-vocabularies/repository-types.glx

--- a/docs/examples/basic-family/vocabularies/source-properties.glx
+++ b/docs/examples/basic-family/vocabularies/source-properties.glx
@@ -1,0 +1,1 @@
+../../../../specification/5-standard-vocabularies/source-properties.glx

--- a/docs/examples/basic-family/vocabularies/source-types.glx
+++ b/docs/examples/basic-family/vocabularies/source-types.glx
@@ -1,0 +1,1 @@
+../../../../specification/5-standard-vocabularies/source-types.glx


### PR DESCRIPTION
## Summary

Enhance `docs/examples/basic-family/` to demonstrate the full GLX data model, not just file structure. Closes #576.

The example previously had only persons (name + sex) and relationships (type + participants) — sufficient to show what files go where, but not why GLX is better than a plain text family tree. As the second step in the learning path (between `minimal/` and `complete-family/`), it now demonstrates events, dates, places, and a complete evidence chain on a deliberately smaller scale than `complete-family/`.

## What changed

**New entities (17 files):**
- `events/event-births.glx` — 4 birth events (one per family member)
- `events/event-marriage.glx` — 1 marriage event
- `places/` — 3 places in a hierarchy (`United States` > `Illinois` > `Springfield`)
- `repositories/repository-sangamon-county-courthouse.glx` — `type: registry`
- `sources/source-sangamon-births.glx` — `type: vital_record`
- `citations/citation-robert-birth.glx` — with `locator` and `text_from_source`
- `assertions/assertion-robert-birth-date.glx` — backs Robert's birth date with `confidence: high`, `status: proven`
- 12 missing vocabulary symlinks (basic-family now has all 17, matching `complete-family/`)

**Edits to existing entities (5 files):**
- 4 persons: `sex` values now quoted to match every other example (basic-family was the only one using unquoted `sex: male`)
- `rel-marriage.glx`: added `start_event: event-marriage-1875`

**README:** Full rewrite. Updated structure tree, family overview with dates and places, file walkthroughs per entity type, "Evidence Chain" section showing all four YAML blocks, expanded "What This Demonstrates", and "Next Steps" pointing at `complete-family/` for multi-source patterns.

## Design choices

- **Only one source/citation/assertion.** Keeps the example clearly smaller than `complete-family/` while still demonstrating the full **Repository → Source → Citation → Assertion** chain. `glx validate --report` shows 1 high-confidence assertion against `event-birth-robert`; the other 3 births and the marriage are direct properties without supporting evidence — a common real-world starting state.
- **Kept short person IDs** (`person-robert-thompson`, not `person-robert-thompson-1850`). `complete-family`'s own README explicitly says short IDs are fine.
- **Resolves part of #513.** That issue (missing vocabulary symlinks) was already closed for `complete-family/` but `basic-family/` still had only 5 of 17 symlinks. Now matches.
- **Match `complete-family/` conventions** for indentation, field names, quoting style, and per-entity-per-file vs. multiple-entities-per-file layout.

## Test plan

- [x] `go build -o bin/glx ./glx` succeeds
- [x] `./bin/glx validate docs/examples/basic-family/` → "Validated 33 files. Archive is valid."
- [x] All 8 example archives validate (no regression in `assertion-workflow/`, `complete-family/`, `minimal/`, `participant-assertions/`, `single-file/`, `temporal-properties/`, `westeros/`)
- [x] `./bin/glx validate docs/examples/basic-family/ --report` shows 1 high-confidence assertion and correctly lists the unevidenced entities
- [x] All cross-references resolve (events reference real persons/places, source references real repository, citation references real source, assertion references real event and citation)
- [x] Go test suite: 1 pre-existing failure in `TestSerializeMultiFileCrossTypeNoCollision` on `main` — unrelated, not introduced here
- [x] All 12 new vocabulary entries are stored in Git as `mode 120000` symlinks (verified via `git ls-files -s`), not as regular files

## Out of scope

- No changes to `complete-family/` or other examples
- No changes to the specification or JSON schemas
- Not addressing the original issue's options 2 (remove the example) or 3 (rename to "minimal") — option 1 (enhance) was the clear right move given the example's distinct learning-path slot

Refs #576, #513
