### PR TITLE
docs: Add CLI Commands section to README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 #### Documentation
 
+- **README.md CLI Commands section** — `README.md` now includes a "CLI Commands" section after the Quick Start that lists every `glx` subcommand grouped into Archive Management, Import & Export, Exploration, Data Entry, Analysis, and Shell completion, each with a one-line description and a link to the full CLI reference. Closes #466
+
 - **Developer Certificate of Origin (DCO) policy** — `CONTRIBUTING.md` now documents the DCO 1.1 and requires contributors to sign off commits with `git commit -s`. Closes #409
 
 - **`SECURITY-POSTURE.md` self-attestation** — New repo-root document attesting GLX's compliance with [OpenSSF OSPS Baseline](https://baseline.openssf.org/) v2026.02.19 at Level 1, with most Level 2 controls also met. Tracks outstanding gaps (#269 SBOM, #424 safe-harbor/embargo, #256 SLSA provenance) and notes EU Cyber Resilience Act applicability for adopters. Surfaced on the website at `/development/security-posture` and linked from `README.md` and `SECURITY.md`. Closes #425

--- a/README.md
+++ b/README.md
@@ -153,6 +153,56 @@ cd my-family-archive
 glx validate
 ```
 
+## CLI Commands
+
+The `glx` CLI groups its commands into archive management, import/export, exploration, data entry, and analysis. See the [full CLI reference](https://genealogix.dev/cli/) for flags, examples, and per-command details.
+
+### Archive Management
+
+- `glx init` — initialize a new archive
+- `glx validate` — validate files and cross-references
+- `glx split` — convert a single-file archive to multi-file
+- `glx join` — convert a multi-file archive to single-file
+- `glx merge` — combine two archives with duplicate detection
+- `glx migrate` — migrate an archive to the current format
+- `glx rename` — rename an entity by ID
+
+### Import & Export
+
+- `glx import` — import a GEDCOM file
+- `glx export` — export to GEDCOM
+
+### Exploration
+
+- `glx search` — full-text search across entities
+- `glx query` — filter and list entities
+- `glx vitals` — show birth, death, burial for a person
+- `glx timeline` — chronological events for a person
+- `glx summary` — full person profile with narrative
+- `glx ancestors` — ancestor tree
+- `glx descendants` — descendant tree
+- `glx cite` — formatted citation text
+- `glx path` — shortest relationship path between two people
+
+### Data Entry
+
+- `glx census add` — generate entities from a census template
+- `glx link` — create a FamilySearch citation from an ARK
+
+### Analysis
+
+- `glx stats` — entity-count and confidence dashboard
+- `glx places` — place data quality issues
+- `glx cluster` — FAN-club analysis
+- `glx analyze` — gap, conflict, and suggestion analysis
+- `glx duplicates` — detect duplicate entities
+- `glx coverage` — research coverage report
+- `glx diff` — diff two archives
+
+### Shell completion
+
+- `glx completion` — generate shell completion scripts (bash, zsh, fish, powershell)
+
 ## File Format
 
 All GENEALOGIX files use the same structure:

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ glx validate
 
 ## CLI Commands
 
-The `glx` CLI groups its commands into archive management, import/export, exploration, data entry, and analysis. See the [full CLI reference](https://genealogix.dev/cli/) for flags, examples, and per-command details.
+The `glx` CLI groups its commands into archive management, import/export, exploration, data entry, analysis, and shell completion. See the [full CLI reference](https://genealogix.dev/cli/) for flags, examples, and per-command details.
 
 ### Archive Management
 
@@ -186,6 +186,7 @@ The `glx` CLI groups its commands into archive management, import/export, explor
 
 ### Data Entry
 
+- `glx census` — census tooling (see subcommands)
 - `glx census add` — generate entities from a census template
 - `glx link` — create a FamilySearch citation from an ARK
 


### PR DESCRIPTION
## What and why

The root `README.md` Quick Start only documented `glx init` and `glx validate`, leaving the other 26 CLI commands invisible to readers — including high-value user-facing ones like `import`, `query`, `search`, `timeline`, `summary`, `analyze`, and `duplicates`.

This PR adds a new "CLI Commands" section after Quick Start, listing every `glx` subcommand grouped into the same six categories used in `docs/cli/index.md` and the website sidebar:

- Archive Management
- Import & Export
- Exploration
- Data Entry
- Analysis
- Shell completion

Each command has a one-line description matching the wording in `docs/cli/index.md`, and the section links to the [full CLI reference](https://genealogix.dev/cli/) for flags, examples, and per-command details.

Categorization was chosen to align with the existing taxonomy (`docs/cli/index.md` + `website/.vitepress/config.js`) rather than the alternative grouping suggested in the issue, so the three doc surfaces stay consistent.

## Related issues

Closes #466

## Testing

- `bash scripts/check-links.sh` — all 343 relative links pass.
- Cross-referenced the command list against `glx/cli_commands.go` (`init()` at line 71), `docs/cli/index.md`, and `website/.vitepress/config.js` — every visible top-level `glx` subcommand is listed exactly once, in the same category as the other two sources.

## Breaking changes

None.
