### PR TITLE
docs: Add Review focus section to PR template (#362)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,10 @@
 
 <!-- Fixes #123 — or "None" if no linked issue. -->
 
+## Review focus
+
+<!-- What should reviewers pay attention to? e.g. "API design", "correctness", or "trivial change". -->
+
 ## Testing
 
 <!-- What did you run or verify? -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - **Added `public/.well-known/security.txt`** — RFC 9116 machine-readable security-contact file served at `/.well-known/security.txt`. Points security scanners and researchers to the GitHub Security Advisories report channel and `SECURITY.md` policy. (#271)
 - **Added `.github/SUPPORT.md`** — Surfaces GitHub's "Support resources" link on the new-issue flow, directing support questions to Discussions, Discord, and the mailing list instead of the issue tracker. (#423)
 - **PR template changelog reminder** — `.github/PULL_REQUEST_TEMPLATE.md` now ends with an HTML-comment reminder to update `CHANGELOG.md` for user-facing changes (Added/Changed/Fixed/Removed). (#363)
+- **PR template Review focus section** — `.github/PULL_REQUEST_TEMPLATE.md` now includes a "Review focus" section after "Related issues", prompting PR authors to state what reviewers should pay attention to (e.g. "API design", "correctness", or "trivial change"). (#362)
 - **Added `public/robots.txt` and VitePress sitemap** — VitePress now emits `/sitemap.xml` (hostname `https://genealogix.dev`), and `public/robots.txt` allows all crawlers and points to it. `srcExclude` was also added to keep vendored `node_modules/**/*.md` out of the build and sitemap. (#282)
 
 #### Specification


### PR DESCRIPTION
<!--
  PR title must follow conventional commits: type: Description
  Description must start with an uppercase letter.
  Examples: feat: Add person search, fix: Handle nil map in merge
  Valid types: feat, fix, docs, chore, refactor, test, perf, ci
-->

## What and why

Adds a `## Review focus` section to `.github/PULL_REQUEST_TEMPLATE.md`, placed immediately after `## Related issues`, per the proposal in #362.

A 2025 empirical study of 80,000 PRs across 156 GitHub projects found that explicitly stating what kind of review feedback is needed is the strongest predictor of merge success (+64-72% merge likelihood), yet present in only 16% of PRs. The new section nudges authors to scope reviewer attention.

Wording is taken verbatim from the issue's proposed-change block — no improvising.

Also adds a one-line `CHANGELOG.md` entry under `[Unreleased] > Added > Project Infrastructure`, adjacent to the existing `(#363)` PR-template-reminder entry so the two related template changes appear together.

## Related issues

Closes #362. Supersedes the review-focus portion of #355 (the changelog-reminder portion of #355 already shipped in #363).

## Review focus

Trivial change — markdown only, no code paths affected. Reviewer attention is best spent confirming:

1. The new section sits between `## Related issues` and `## Testing` (correct ordering per issue spec).
2. CHANGELOG bullet style matches the surrounding `(#363)` / `(#423)` entries.
3. The HTML-comment placeholder uses the same wording style as adjacent sections.

## Testing

Documentation-only change; no tests or build artifacts affected. Verified by visual re-read of both edited files.

## Breaking changes

None.

<!-- Reminder: update CHANGELOG.md for user-facing changes (Added/Changed/Fixed/Removed). -->
