### PR TITLE
fix: Bump transitive brace-expansion to clear npm audit

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1595,9 +1595,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What and why

`brace-expansion` 5.0.2-5.0.5 has a moderate-severity DoS where a large numeric range defeats the documented `max` protection ([GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2)).

The website lockfile resolved `brace-expansion` to `5.0.5` transitively (`eslint` → `minimatch` → `brace-expansion`), causing the `Security / npm Audit` workflow to fail on every PR that touches `/website` — and on the scheduled weekly run.

This change is lockfile-only — no `package.json` changes — produced by running `npm audit fix` in `/website`. Bumps `brace-expansion` to `5.0.6`. Same shape as #748 (the postcss transitive audit fix).

## Related issues

None.

## Review focus

Trivial change. Verify the diff is exactly the three lines (`version`, `resolved`, `integrity`) for `brace-expansion` and nothing else.

## Testing

- `cd website && npm audit --audit-level=moderate` — exits 0 (`found 0 vulnerabilities`).
- `git diff --stat HEAD~1` — only `website/package-lock.json` changed, 3 insertions / 3 deletions.

## Breaking changes

None — transitive dev-dependency, lockfile-only.
