### PR TITLE
ci(release): bump cosign-installer v3 → v4 for cosign 3.x signature format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         run: go mod download
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
         with:
           cosign-release: 'v3.0.6'   # pin: --bundle output format is part of our release verification contract
 


### PR DESCRIPTION
## Summary

- The v0.0.0-beta.11 tag push failed the **Release Binaries** workflow at the `Install cosign` step (curl exit 22).
- Root cause: cosign 3.x (since v3.0.5) dropped the legacy detached `.sig` files; assets ship `*.sigstore.json` bundles instead. `sigstore/cosign-installer@v3` still fetches `.sig` and 404s.
- `sigstore/cosign-installer@v4` (released 2026-03-09) consumes the new bundle format and pulls cosign 3.0.6 correctly — see PR sigstore/cosign-installer#232 "Bump cosign to 3.0.6".

The `cosign-release: 'v3.0.6'` pin is unchanged so the `cosign verify-blob --bundle` consumer contract documented in `SECURITY-POSTURE.md` still holds.

## Related issues

Unblocks the v0.0.0-beta.11 release (tag `v0.0.0-beta.11` already pushed; needs the workflow to be re-run after this lands).

## Review focus

One-line action-version bump.

## Test plan

- [ ] After merge, re-run the **Release Binaries** workflow on the `v0.0.0-beta.11` tag (Actions → Release Binaries → Re-run failed jobs on run `26570109222`).
- [ ] Confirm cosign-installer step succeeds and GoReleaser publishes the release with binaries + `checksums.txt.sigstore.json`.