### PR TITLE
chore: Replace inline known-drift notes with .claude/drift-allowlist.yaml

### DIFF
--- a/.claude/commands/check-code-drift.md
+++ b/.claude/commands/check-code-drift.md
@@ -9,6 +9,31 @@ model: claude-opus-4-7
 
 You are tasked with identifying any drift between the GLX Go code implementation and the JSON schemas/specification.
 
+## Allowlisted Drift (read this first)
+
+Before analyzing, read **`.claude/drift-allowlist.yaml`** (validated by
+`.claude/drift-allowlist.schema.json`). It is the single source of truth for
+known, per-symbol drift that has already been triaged. Check every finding you
+would otherwise report against it:
+
+- If a finding concerns the same `file` and Go symbol as an allowlist entry,
+  **suppress it** — do not report it as drift. Match on symbol *identity*, not
+  exact string: an entry's `symbol` is written qualified (e.g.
+  `GLXFile.ImportMetadata`), so a finding that names the field bare
+  (`ImportMetadata`) or by its yaml tag (`metadata`) still matches it.
+  - `permanent: true` entries are by-design and will never be "fixed" (e.g. a Go
+    field name that intentionally differs from its yaml tag). Treat them as *not
+    drift*.
+  - Entries with a `tracking_issue` are temporary deferrals. Don't re-report them
+    as new findings; refer to the tracking issue instead.
+- Anything **not** in the allowlist is reported normally.
+
+Only genuine *per-symbol* exceptions live in the allowlist. Class-level
+methodology (e.g. "the Go validator intentionally does not duplicate JSON-schema
+constraints", below) stays in this prompt — it is not an allowlist entry. The
+allowlist is human-curated: do **not** invent entries. If you believe a new
+exception is warranted, report the drift and recommend adding an allowlist entry.
+
 ## Source of Truth Flow
 
 **IMPORTANT**: The source of truth hierarchy is:
@@ -125,12 +150,11 @@ Compare Go types with JSON schema types:
 #### Metadata and Submitter
 - `Metadata` struct has 11 fields — check against `glx-file.schema.json` property `metadata`
 - `Submitter` is nested via `*Submitter` pointer — check against schema's submitter object
-- **Note**: `Metadata.Notes` is `NoteList` in Go but `string` in schema — this is a known drift point
 
 #### GLXFile Top-Level
 - Check that GLXFile struct has all entity type maps
 - Verify yaml tags match schema (e.g., `persons`, `events`, etc.)
-- Check `ImportMetadata *Metadata` field against `metadata` property in schema (Go field name differs from yaml tag)
+- Check `ImportMetadata *Metadata` field against `metadata` property in schema (the Go field name vs yaml-tag difference is allowlisted — see "Allowlisted Drift" above)
 - Check all vocabulary definition maps (10 type vocabs + 8 property vocabs)
 
 ### 8. Vocabulary Struct Types

--- a/.claude/commands/check-schema-drift.md
+++ b/.claude/commands/check-schema-drift.md
@@ -9,6 +9,18 @@ model: claude-opus-4-7
 
 You are tasked with identifying any drift between the GLX specification markdown files and the JSON schemas.
 
+## Allowlisted Drift (read this first)
+
+Before analyzing, read **`.claude/drift-allowlist.yaml`** (validated by
+`.claude/drift-allowlist.schema.json`) — the single source of truth for known,
+triaged drift, shared with `/check-code-drift`. If a finding concerns the same
+`file` and symbol as an entry (match on symbol identity, not exact string),
+suppress it: `permanent: true` is by-design (not drift); an
+entry with a `tracking_issue` is a temporary deferral (refer to the issue rather
+than re-reporting). Everything not in the allowlist is reported normally. The
+allowlist holds only per-symbol exceptions — not class-level methodology — and is
+human-curated, so don't invent entries.
+
 ## Source of Truth Flow
 
 **IMPORTANT**: The source of truth hierarchy is:

--- a/.claude/drift-allowlist.schema.json
+++ b/.claude/drift-allowlist.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GLX drift allowlist",
+  "description": "Schema for .claude/drift-allowlist.yaml — known, per-symbol drift suppressions consumed by the /check-*-drift slash commands (and future deterministic checkers, see genealogix/glx#673 and #295). Each list entry suppresses exactly one drift finding and is either PERMANENT (by-design; permanent:true, no tracking_issue) or TEMPORARY (a deferral that must reference an open tracking issue). This schema is NOT a GLX archive-format schema, so it lives under .claude/ rather than specification/schema/v1/ and is validated by specification/validate-drift-allowlist.mjs, not the entity meta-schema.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["file", "symbol", "reason", "added"],
+    "properties": {
+      "file": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Repo-relative path of the file containing the drifting symbol (e.g. go-glx/types.go)."
+      },
+      "symbol": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Qualified symbol the suppression applies to (e.g. GLXFile.ImportMetadata, Metadata.Notes)."
+      },
+      "reason": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Why this drift is suppressed — enough context for a reviewer to judge whether it still applies."
+      },
+      "added": {
+        "type": "string",
+        "format": "date",
+        "description": "ISO date (YYYY-MM-DD) the entry was added to the allowlist. Quote it in YAML (e.g. \"2026-06-01\") so it parses as a string, not a timestamp."
+      },
+      "permanent": {
+        "type": "boolean",
+        "description": "true for by-design suppressions that will never be fixed. Omit (or false) for temporary deferrals."
+      },
+      "tracking_issue": {
+        "type": "integer",
+        "minimum": 1,
+        "description": "GitHub issue number tracking the fix. Required for temporary deferrals; forbidden for permanent entries. A future deterministic checker (genealogix/glx#673, #295) fails loud when a referenced issue is CLOSED but the entry remains."
+      },
+      "go_type": {
+        "type": "string",
+        "description": "Optional: the Go type, when the drift is a type mismatch."
+      },
+      "schema_type": {
+        "type": "string",
+        "description": "Optional: the JSON-schema type, when the drift is a type mismatch."
+      },
+      "yaml_tag": {
+        "type": "string",
+        "description": "Optional: the Go field's yaml tag, when the drift is a name mismatch."
+      },
+      "schema_path": {
+        "type": "string",
+        "description": "Optional: path to the schema location (e.g. glx-file.schema.json#/properties/metadata/properties/notes)."
+      }
+    },
+    "oneOf": [
+      {
+        "title": "Temporary deferral — must reference a tracking issue",
+        "type": "object",
+        "properties": {
+          "permanent": { "const": false },
+          "tracking_issue": { "type": "integer", "minimum": 1 }
+        },
+        "required": ["tracking_issue"]
+      },
+      {
+        "title": "Permanent, by-design suppression — no tracking issue",
+        "type": "object",
+        "properties": {
+          "permanent": { "const": true },
+          "tracking_issue": false
+        },
+        "required": ["permanent"]
+      }
+    ]
+  },
+  "examples": [
+    [
+      {
+        "file": "go-glx/types.go",
+        "symbol": "GLXFile.ImportMetadata",
+        "yaml_tag": "metadata",
+        "reason": "Go field name differs from its yaml tag by design; the tag matches the schema, so there is no real drift.",
+        "permanent": true,
+        "added": "2026-06-01"
+      },
+      {
+        "file": "go-glx/types.go",
+        "symbol": "Some.Field",
+        "go_type": "SomeType",
+        "schema_type": "string",
+        "schema_path": "some.schema.json#/properties/some/properties/field",
+        "reason": "Deferred until the schema is widened to match the Go marshaler.",
+        "tracking_issue": 1234,
+        "added": "2026-06-01"
+      }
+    ]
+  ]
+}

--- a/.claude/drift-allowlist.yaml
+++ b/.claude/drift-allowlist.yaml
@@ -1,0 +1,41 @@
+# Drift allowlist for the /check-*-drift slash commands (genealogix/glx#797).
+#
+# Each entry suppresses ONE known, per-symbol drift finding so the drift
+# checkers don't re-report it. Validated by `make check-drift-allowlist`
+# against drift-allowlist.schema.json. There are two kinds of entry:
+#
+#   * permanent: true     — by-design; will never be "fixed" (no tracking_issue).
+#   * tracking_issue: <n>  — temporary deferral; MUST reference an OPEN issue.
+#
+# This file holds only genuine PER-SYMBOL exceptions. Class-level methodology
+# (e.g. "the Go validator intentionally does not duplicate JSON-schema
+# constraints") stays in the prompt text — it is not a per-symbol suppression.
+#
+# A future deterministic checker (genealogix/glx#673, #295) will also fail loud
+# when a temporary entry's tracking_issue is CLOSED — i.e. the drift was fixed
+# but the entry was never removed. (That staleness gate is intentionally NOT in
+# the offline `make check-drift-allowlist` validator yet; it needs issue-state
+# lookups that those issues already scope.)
+#
+# Template for a temporary entry (copy, uncomment, fill in):
+#   - file: go-glx/types.go
+#     symbol: Some.Field
+#     go_type: SomeType
+#     schema_type: string
+#     schema_path: some.schema.json#/properties/some/properties/field
+#     reason: "why this drift is deferred rather than fixed now"
+#     tracking_issue: 1234
+#     added: "2026-06-01"
+
+- file: go-glx/types.go
+  symbol: GLXFile.ImportMetadata
+  yaml_tag: metadata
+  reason: >-
+    Go field GLXFile.ImportMetadata is deliberately named differently from its
+    yaml tag `metadata` (which correctly matches the schema's `metadata`
+    property); the name reflects that it holds archive metadata imported from
+    GEDCOM HEAD/SUBM. A naive Go-field-name vs schema-property comparison would
+    false-flag it as an extra/missing field, but the yaml tag is correct, so
+    there is no real drift.
+  permanent: true
+  added: "2026-06-01"

--- a/.github/workflows/validate-spec.yml
+++ b/.github/workflows/validate-spec.yml
@@ -53,6 +53,9 @@ jobs:
 
       - name: Validate JSON Schemas
         run: make check-schemas
+
+      - name: Validate drift allowlist
+        run: make check-drift-allowlist
   
   validate-examples:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Added
+
+- **`.claude/drift-allowlist.yaml`** — Machine-readable, self-validating allowlist of known, per-symbol drift suppressions for the `/check-*-drift` slash commands, replacing inline "known drift" prose with an auditable file. Each entry is either permanent (by-design) or a temporary deferral that must reference a tracking issue; this is enforced by `.claude/drift-allowlist.schema.json` via the new `make check-drift-allowlist` target, wired into `make check` and the `validate-spec` CI workflow. The closed-issue staleness gate (failing when a temporary entry's tracking issue is closed) is left to the deterministic drift checkers tracked by #673 / #295. (#797)
+
+### Changed
+
+- **`/check-code-drift` and `/check-schema-drift` now read the drift allowlist** instead of hardcoding known-drift notes inline. Removed the stale `Metadata.Notes` "known drift point" note — that drift was already resolved by widening `glx-file.schema.json` `metadata.notes` to `oneOf[string, array]`, which is exactly the go-stale-and-mislead failure mode #797 targets. (#797)
+
 ## [0.0.0-beta.11] - 2026-05-27
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # GENEALOGIX Makefile
-.PHONY: help check build build-cli build-website install-deps install-hooks lint lint-fix fix fix-diff test test-verbose test-race test-coverage bench mod-tidy mod-verify tidy-check clean fmt check-schemas check-links validate-examples docs-cli release-snapshot
+.PHONY: help check build build-cli build-website install-deps install-hooks lint lint-fix fix fix-diff test test-verbose test-race test-coverage bench mod-tidy mod-verify tidy-check clean fmt check-schemas check-drift-allowlist check-links validate-examples docs-cli release-snapshot
 
 .DEFAULT_GOAL := help
 
@@ -32,7 +32,7 @@ install-hooks: ## Install lefthook git pre-commit hooks (run once per clone)
 	lefthook install
 
 ## Verification
-check: tidy-check lint test check-schemas check-links validate-examples ## Run all checks (mirrors CI)
+check: tidy-check lint test check-schemas check-drift-allowlist check-links validate-examples ## Run all checks (mirrors CI)
 	@echo "All checks passed."
 
 ## Build
@@ -109,6 +109,9 @@ tidy-check: ## Verify go.mod and go.sum are tidy
 ## Specification
 check-schemas: ## Validate JSON schema files
 	@node specification/validate-schemas.mjs
+
+check-drift-allowlist: ## Validate .claude/drift-allowlist.yaml against its schema
+	@node specification/validate-drift-allowlist.mjs
 
 ## Example Validation
 validate-examples: build-cli ## Validate all example archives

--- a/specification/package-lock.json
+++ b/specification/package-lock.json
@@ -8,7 +8,8 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "ajv": "^8.20.0",
-        "ajv-formats": "^3.0.1"
+        "ajv-formats": "^3.0.1",
+        "js-yaml": "^4.1.1"
       }
     },
     "node_modules/ajv": {
@@ -46,6 +47,13 @@
         }
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -69,6 +77,19 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",

--- a/specification/package.json
+++ b/specification/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "devDependencies": {
     "ajv": "^8.20.0",
-    "ajv-formats": "^3.0.1"
+    "ajv-formats": "^3.0.1",
+    "js-yaml": "^4.1.1"
   }
 }

--- a/specification/validate-drift-allowlist.mjs
+++ b/specification/validate-drift-allowlist.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// Validate .claude/drift-allowlist.yaml against .claude/drift-allowlist.schema.json.
+//
+// This is the OFFLINE structural check: JSON-schema conformance (incl. the
+// temporary-vs-permanent invariant encoded as a per-entry oneOf) plus a
+// duplicate file+symbol guard. The closed-issue staleness gate — failing loud
+// when a temporary entry's tracking_issue is CLOSED — is deferred to the
+// deterministic drift checkers tracked by genealogix/glx#673 and #295, which
+// need GitHub issue-state lookups this offline validator deliberately avoids.
+
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import { readFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import yaml from "js-yaml";
+
+// Resolve paths relative to the repo root (script lives in specification/).
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..");
+const ALLOWLIST = join(ROOT, ".claude/drift-allowlist.yaml");
+const SCHEMA = join(ROOT, ".claude/drift-allowlist.schema.json");
+
+let errors = 0;
+
+const ajv = new Ajv({ strict: true, allErrors: true });
+addFormats(ajv);
+const validate = ajv.compile(JSON.parse(readFileSync(SCHEMA, "utf8")));
+
+const entries = yaml.load(readFileSync(ALLOWLIST, "utf8"));
+
+if (!validate(entries)) {
+  console.error(`${ALLOWLIST} INVALID:`);
+  console.error(validate.errors);
+  errors++;
+} else {
+  // Schema validation has confirmed `entries` is an array of well-formed objects.
+  // Guard against the "allowlist becomes a dumping ground" risk (genealogix/glx#797):
+  // no two entries may suppress the same file+symbol. Key on the JSON-encoded
+  // [file, symbol] tuple so values containing a separator can't collide.
+  const seen = new Set();
+  for (const e of entries) {
+    const key = JSON.stringify([e.file, e.symbol]);
+    if (seen.has(key)) {
+      console.error(`${ALLOWLIST}: duplicate entry for ${e.file} :: ${e.symbol}`);
+      errors++;
+    }
+    seen.add(key);
+  }
+}
+
+if (errors > 0) {
+  console.error(`\n${errors} drift-allowlist error(s).`);
+  process.exit(1);
+}
+
+// Past the error gate above, schema validation has guaranteed `entries` is an array.
+const count = entries.length;
+console.log(`${ALLOWLIST} valid (${count} entr${count === 1 ? "y" : "ies"}).`);


### PR DESCRIPTION
## What and why

Known *per-symbol* drift suppressions for the `/check-*-drift` slash commands were hardcoded as inline prose in the prompt files. As #797 argues, that doesn't scale: the notes go stale, nobody removes them when the underlying drift is fixed, and there's no audit trail.

This moves them into a machine-readable, self-validating allowlist:

- **`.claude/drift-allowlist.yaml`** + **`.claude/drift-allowlist.schema.json`** — each entry is either *permanent* (by-design) or a *temporary* deferral that must reference a tracking issue. A per-entry `oneOf` enforces the distinction (temporary ⇒ integer `tracking_issue`; permanent ⇒ `permanent: true`, no `tracking_issue`).
- **`specification/validate-drift-allowlist.mjs`** — validates the YAML against the schema (plus a duplicate `file`+`symbol` guard), wired in as `make check-drift-allowlist` (added to `make check`) and a `validate-spec` CI step. `js-yaml` added as a declared devDependency.
- **`/check-code-drift` and `/check-schema-drift`** now read the allowlist first and suppress matching findings instead of carrying inline prose.

The allowlist ships with **one** real entry — the permanent `GLXFile.ImportMetadata` (the Go field name intentionally differs from its yaml tag `metadata`, which correctly matches the schema, so a naive field-name comparison shouldn't flag it).

While doing the migration sweep I found the inline **`Metadata.Notes` "known drift point"** note was itself stale: `glx-file.schema.json` `metadata.notes` is already `oneOf[string, array]` (matching Go's `NoteList`), so that drift no longer exists. It is **deleted, not migrated** — which is exactly the go-stale-and-mislead failure mode #797 targets.

The closed-issue **staleness gate** — failing loud when a temporary entry's `tracking_issue` is CLOSED — is deliberately *not* in this offline validator; it needs GitHub issue-state lookups and is left to the deterministic drift checkers in #673 / #295, which will consume this same allowlist.

## Related issues

Part of #797 — delivers the allowlist mechanism + migration sweep; the closed-issue staleness gate stays open for #673 / #295. (This also surfaced that #772's drift was already fixed; closing #772 directly with evidence rather than via this PR, since the schema fix predates this branch.)

## Review focus

- `.claude/drift-allowlist.schema.json` — the temporary-vs-permanent `oneOf` discriminator. It accepts exactly the intended set and rejects the rest (verified across the full case matrix), and compiles clean under ajv `strict`.
- `specification/validate-drift-allowlist.mjs` — the duplicate guard keys on the JSON-encoded `[file, symbol]` tuple (collision-proof) and runs only after schema validation passes.
- The "Allowlisted Drift (read this first)" sections in the two prompts — matching is *semantic* (a qualified `Struct.Field`, a bare field name, or a yaml tag all match the same entry), so suppression doesn't silently miss for less-unique symbols.

## Testing

- `node specification/validate-drift-allowlist.mjs` → passes on the real file; deliberate failures (both `permanent`+`tracking_issue`; missing `tracking_issue`; bad/unquoted date; duplicate `file`+`symbol`; non-array root) all fail loud with clear messages.
- `make check-schemas` → no regression (the new schema lives under `.claude/`, so it is not globbed into the entity meta-schema validation).
- `npm ci --prefix specification` → succeeds (package.json and lockfile are consistent).
- `markdownlint-cli2` → 0 errors across in-scope files.
- No Go changed, so the Go suite is unaffected.

## Breaking changes

None — new dev-tooling plus prompt/doc edits only.
