### PR TITLE
ci: Remove dead chmod in build-cli; document the load-bearing one

### DIFF
--- a/.github/workflows/validate-spec.yml
+++ b/.github/workflows/validate-spec.yml
@@ -107,7 +107,6 @@ jobs:
           # Build the CLI once and share it with the matrix via an artifact,
           # so each example job doesn't pay the build cost again.
           go build -o bin/glx ./glx
-          chmod +x bin/glx
 
       - name: Upload glx binary
         uses: actions/upload-artifact@v7
@@ -150,6 +149,7 @@ jobs:
           # Stage matrix value in env to avoid shell injection via ${{ }} in run.
           EXAMPLE: ${{ matrix.example }}
         run: |
+          # upload-artifact zips and strips the exec bit; restore it before running
           chmod +x bin/glx
           ./bin/glx validate "docs/examples/$EXAMPLE/"
 


### PR DESCRIPTION
## What and why

The `chmod +x bin/glx` in `build-cli` was dead code on two counts: Go build output on Linux is already 0755, and the binary travels to the `validate-example` matrix only through `upload-artifact`, which stores it in a zip that carries no Unix permission bits (it downloads as 0644 regardless). The `chmod` inside the matrix job is the one that actually makes the binary runnable.

The danger was the deletion trap the issue describes: a future cleanup removing the matrix-side `chmod` on the belief that the build-side one "already handled it" would break every example validation. This PR deletes the dead build-side `chmod` and puts a one-line comment on the load-bearing one explaining why it must stay.

No CHANGELOG entry — CI-internal, no behavior change.

## Related issues

Fixes #1037

## Review focus

Trivial change — one deleted line, one comment.

## Testing

`actionlint` passes. The `validate-example` matrix in this PR's own CI run is the end-to-end proof: the downloaded artifact still gets its exec bit restored by the remaining (matrix-side) `chmod` and every example validates.

## Breaking changes

None.
