### PR TITLE
fix: bump fast-uri to 3.1.4 for CVE-2026-13676 and CVE-2026-16221 host confusion

### DIFF
--- a/specification/package-lock.json
+++ b/specification/package-lock.json
@@ -70,9 +70,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Fixes **both** open `fast-uri` Dependabot alerts (each high severity):

| Alert | Advisory | Vulnerable range | First patched |
| --- | --- | --- | --- |
| [#15](https://github.com/genealogix/glx/security/dependabot/15) | [GHSA-4c8g-83qw-93j6](https://github.com/fastify/fast-uri/security/advisories/GHSA-4c8g-83qw-93j6) / [CVE-2026-13676](https://nvd.nist.gov/vuln/detail/CVE-2026-13676) — host confusion via failed IDN canonicalization | `>= 2.3.1, <= 4.0.0` | `3.1.3` |
| [#16](https://github.com/genealogix/glx/security/dependabot/16) | [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) / [CVE-2026-16221](https://nvd.nist.gov/vuln/detail/CVE-2026-16221) — host confusion via literal backslash authority delimiter | `>= 3.0.0, <= 3.1.3` | `3.1.4` |

Both are host-confusion bugs, so `3.1.4` (not `3.1.3`) is the floor that clears both.

## The vulnerabilities

**CVE-2026-13676** — `fast-uri` fails to canonicalize Unicode/IDN hostnames for HTTP-family URLs. The IDN conversion path calls `URL.domainToASCII(...)` on the global WHATWG `URL` constructor, where that helper does not exist. The resulting `TypeError` is silently routed into `parsed.error`, but `parse()`, `normalize()`, and `equal()` all return with the host left in its original Unicode form — so `http://127。0。0。1/` parses as host `127。0。0。1` while Node's URL parser and `fetch()` canonicalize the same input to `127.0.0.1`.

**CVE-2026-16221** — the same class of desync, reached instead through a literal backslash used as the authority delimiter.

In both cases an application that uses `fast-uri` to enforce host-based policy (denylists, loopback filtering, redirect validation) before handing the same URL to Node's `URL`/`fetch()` gets a policy/use desync. Neither has a workaround; upgrading is the fix.

## The fix

`fast-uri` is a **transitive, dev-only** dependency of `specification/`, pulled in by `ajv` at `^3.0.1`. That range already admits the patched line, so this is a lockfile-only bump — `specification/package.json` is untouched:

```
node_modules/fast-uri: 3.1.2 → 3.1.4
```

## Exposure assessment

Low for this repo. `fast-uri` is reached only through `ajv`'s `uri`/`uri-reference` format validation while linting the spec's JSON Schemas at build time. Nothing in GLX makes host-based policy decisions from `fast-uri` output, and it never ships in a released artifact (`"dev": true` in the lockfile). Bumping regardless to clear the alerts.

## Verification

Ran the full set of Node checks that consume this dependency tree locally, all green:

- `npm ci --prefix specification` — 12 packages, `fast-uri@3.1.4` installed, `found 0 vulnerabilities`
- `make check-schemas` — every vocabulary `.glx` validates against its schema
- `make check-drift-allowlist` — allowlist valid (1 entry)
- `make test-scripts` — 21/21 pass

CI is green across all 30 required checks on this branch, including `npm Audit`, `validate-schemas`, and `Socket Security`.
