### PR TITLE
fix: Drop unsupported semver cooldown keys from github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,11 +57,11 @@ updates:
     # so a worm-class compromised release (the npm token-stealer pattern) is
     # likely yanked before Dependabot ever proposes it. Security updates
     # bypass the cooldown entirely, so known-CVE fixes still land same-day.
+    # NOTE: the github-actions ecosystem supports ONLY default-days — the
+    # semver-tier keys are rejected by Dependabot's config validator
+    # ("not supported for the package ecosystem 'github-actions'").
     cooldown:
       default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
     commit-message:
       prefix: "chore(deps)"
     labels:


### PR DESCRIPTION
## What and why

PR #1185 added Dependabot's native `cooldown:` to all three ecosystems with the full semver-tier keys. Dependabot's config validator rejects the semver-tier keys for the `github-actions` ecosystem:

```
The property '#/updates/2/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
```

so the `.github/dependabot.yml` check has been failing on `main` (and, being repo-level, on every open PR) since the merge. This keeps `default-days: 7` for github-actions — the only key that ecosystem supports — and leaves the fully tiered cooldown on gomod and npm, with a comment so the keys don't get "harmonized" back.

## Related issues

Follow-up to #929 / PR #1185. (Not `Fixes` — #929 closed with #1185.)

## Review focus

Trivial change — the validator error message quoted above is the whole story.

## Testing

The YAML parses; the authoritative validation is Dependabot's own config check, which runs on merge. The error was reproduced from the check-run output on the merge commit.

## Breaking changes

None. github-actions bumps get a flat 7-day cooldown instead of tiered.