### PR TITLE
docs: Clean up README metadata and deprecated badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
----
-title: GENEALOGIX Specification
-description: Modern, evidence-first, Git-native genealogy data standard
-layout: doc
----
-
 # GENEALOGIX Specification
 
 [![Version](https://img.shields.io/github/v/release/genealogix/glx?include_prereleases&label=version)](https://github.com/genealogix/glx/releases)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-green.svg)](https://github.com/genealogix/glx/blob/main/LICENSE)
 [![CI](https://github.com/genealogix/glx/actions/workflows/validate-spec.yml/badge.svg?branch=main)](https://github.com/genealogix/glx/actions/workflows/validate-spec.yml)
 [![codecov](https://codecov.io/gh/genealogix/glx/branch/main/graph/badge.svg)](https://codecov.io/gh/genealogix/glx)
-[![Go Report Card](https://goreportcard.com/badge/github.com/genealogix/glx)](https://goreportcard.com/report/github.com/genealogix/glx)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/genealogix/glx/badge)](https://scorecard.dev/viewer/?uri=github.com/genealogix/glx)
 [![Contributors](https://img.shields.io/github/contributors/genealogix/glx.svg)](https://github.com/genealogix/glx/graphs/contributors)
 

--- a/glx/README.md
+++ b/glx/README.md
@@ -1,7 +1,5 @@
 # GLX - GENEALOGIX CLI Tool
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/genealogix/glx)](https://goreportcard.com/report/github.com/genealogix/glx)
-
 The official command-line tool for working with GENEALOGIX (GLX) family archives. Validates GLX files, initializes new archives, and checks schema conformance.
 
 ## Features


### PR DESCRIPTION
## What and why

Clean up README rendering on GitHub and go.dev:

- Remove the YAML frontmatter from the root README so the project overview starts directly with its heading instead of displaying the metadata block.
- Remove the deprecated Go Report Card badges from the root and CLI READMEs.

The VitePress homepage is unaffected because `website/index.md` is explicitly rewritten to `/`.

## Related issues

None.

## Review focus

Confirm both READMEs render cleanly and that neither the removed metadata nor the deprecated badges is needed.

## Testing

- `git diff --check`
- Confirmed no active Markdown files reference Go Report Card; only the historical changelog entry remains
- Confirmed `website/.vitepress/config.js` maps `website/index.md` to the site root
- Website build not run because `website/node_modules` is not installed in this worktree

## Breaking changes

None.
