### PR TITLE
ci: Retry npm audit when the registry advisories endpoint times out

### DIFF
--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -57,4 +57,30 @@ jobs:
         run: npm ci
 
       - name: Run npm audit
-        run: npm audit --audit-level=moderate
+        # npm's --fetch-retries does not cover the bulk advisories endpoint,
+        # which times out under registry load and fails the run with "audit
+        # endpoint returned an error" while reporting no vulnerabilities at
+        # all. Retry the whole command with backoff on that class of failure
+        # only: npm audit exits 1 for both network errors and real findings,
+        # so the two are told apart by the error text, and a genuine advisory
+        # is never retried or masked.
+        shell: bash
+        run: |
+          attempts=5
+          for attempt in $(seq 1 "$attempts"); do
+            if out=$(npm audit --audit-level=moderate --fetch-timeout=60000 2>&1); then
+              printf '%s\n' "$out"
+              exit 0
+            fi
+            printf '%s\n' "$out"
+            if ! grep -qE 'audit endpoint returned an error|network timeout|ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|socket hang up|E50[0-9]|E429' <<<"$out"; then
+              echo "::error::npm audit reported vulnerabilities at or above the moderate level"
+              exit 1
+            fi
+            if [ "$attempt" -lt "$attempts" ]; then
+              echo "::warning::npm audit could not reach the registry (attempt $attempt of $attempts); retrying"
+              sleep $((attempt * 15))
+            fi
+          done
+          echo "::error::npm audit could not reach the registry after $attempts attempts"
+          exit 1


### PR DESCRIPTION
## What and why

Both `npm Audit` jobs failed on #1199 twice in one day with `npm error audit endpoint returned an error` after `npm warn audit network timeout at: https://registry.npmjs.org/-/npm/v1/security/advisories/bulk`, and no vulnerabilities. `npm audit` exits 1 for both a registry failure and a real finding, and `--fetch-retries` does not cover the bulk advisories endpoint, so a registry hiccup fails the gate.

The step now retries the whole command up to five times with linear backoff (15s, 30s, 45s, 60s), but only when the output matches a network error (`audit endpoint returned an error`, `network timeout`, `ECONNRESET`, `ETIMEDOUT`, `ENOTFOUND`, `EAI_AGAIN`, `socket hang up`, HTTP 5xx or 429). A genuine advisory still exits 1 on the first attempt, so nothing is masked. If the registry stays unreachable through all attempts the job fails with an explicit `::error::`.

## Related issues

None (CI reliability; observed on #1199).

## Review focus

The error-text match that decides "network problem, retry" versus "findings, fail". It is deliberately narrow: anything not matching is treated as findings.

## Testing

Ran the step script against a fake `npm` on `PATH` with three behaviours:

| Fake npm | Result | npm calls |
|---|---|---|
| two timeouts, then `found 0 vulnerabilities` | pass | 3 |
| `3 moderate severity vulnerabilities` | fail, no retry | 1 |
| always `audit endpoint returned an error` | fail after backoff | 5 |

YAML parses; the embedded script passes shellcheck.

## Breaking changes

None.