### PR TITLE
docs: Remove the GEDCOM quick-comparison tables from the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,18 +39,6 @@ glx validate
 
 Traditional formats like GEDCOM solve file exchange but stop short of modern collaborative research. GENEALOGIX is a Git-native, evidence-first archive format that aims to be a permanent foundation, not just an export target.
 
-| Challenge | GEDCOM | GENEALOGIX |
-|-----------|--------|------------|
-| **Collaboration** | File sharing only | Git-native workflows |
-| **Evidence Tracking** | Basic source records | Complete evidence chains |
-| **Version Control** | Manual or difficult | Built-in Git integration |
-| **Human Readability** | Don't even try | Clear YAML structure |
-| **Validation** | Syntax only | Schema-based validation |
-| **Extensibility** | Limited | JSON Schema-based |
-| **Data Portability** | Vendor lock-in | Open format you own |
-| **Interoperability** | GEDCOM export only | Import/export + Git workflows |
-| **Custom Types** | Fixed schema | Archive-defined vocabularies |
-
 For a side-by-side look at the GEDCOM-vs-GLX wire formats and the assertion model that backs every claim with evidence, see [Core Concepts](specification/2-core-concepts.md).
 
 ## Features

--- a/website/index.md
+++ b/website/index.md
@@ -43,20 +43,6 @@ features:
 
 Traditional genealogy software traps your research in proprietary databases and limited file formats. GENEALOGIX gives you **true data ownership** with human-readable files you can edit in any text editor, store anywhere, and collaborate on using Git. Whether you're documenting traditional family trees, researching local history, or building biographical databases, GLX adapts to **your research needs** - not the other way around. It's a **permanent foundation** for your work that will outlast any single software tool.
 
-### Quick Comparison
-
-| Feature               | GEDCOM                       | GENEALOGIX                    |
-| --------------------- | ---------------------------- | ----------------------------- |
-| **Collaboration**     | File sharing only            | Git-native workflows          |
-| **Evidence Tracking** | Basic source records         | Complete evidence chains      |
-| **Version Control**   | Manual or difficult          | Built-in Git integration      |
-| **Human Readability** | Binary-like format           | Clear YAML structure          |
-| **Validation**        | Inconsistent implementations | Schema-based validation       |
-| **Extensibility**     | Limited                      | JSON Schema based             |
-| **Data Portability**  | Vendor lock-in               | Open format you own           |
-| **Interoperability**  | GEDCOM export only           | Import/export + Git workflows |
-| **Custom Types**      | Fixed schema                 | Archive-defined vocabularies  |
-
 ## What is a GLX Archive?
 
 A GENEALOGIX archive is a collection of plain YAML files — one per person, event, place, source, and so on — organized in a simple folder structure. Each archive also includes vocabulary files that define the types your research uses (event types, relationship types, etc.), so the archive is completely self-describing.


### PR DESCRIPTION
## What and why

Removes the "Quick Comparison" GEDCOM-vs-GENEALOGIX table from the website landing page (`website/index.md`) and the identical table from the root `README.md`, which is also served on the site. Both argued against a caricature of GEDCOM ("Don't even try", "Binary-like format") rather than describing GLX. The surrounding "Why GENEALOGIX?" prose is kept in both places.

Not touched: the "Comparison with Existing Formats" table in `specification/1-introduction.md` (GLX / GEDCOM / Gramps XML). It is more measured, but it lives on the site too; happy to drop it in this PR if wanted.

## Related issues

None

## Review focus

Trivial change. Confirm nothing else on the landing page referenced the table.

## Testing

- `markdownlint-cli2 README.md website/index.md`: clean.

## Breaking changes

None
