### PR TITLE
feat: Add Date.Span to glxdate with Allen-style relations

### DIFF
--- a/go-glx/glxdate/doc.go
+++ b/go-glx/glxdate/doc.go
@@ -50,6 +50,11 @@
 // without being reported. [Date.String] renders the canonical form whenever
 // the components were determined, and the raw text otherwise.
 //
+// [Date.Span] places a date on a day-granular number line so two dates can
+// be compared without re-deriving the qualifier and precision rules: the
+// resulting [Span] answers [Span.Precedes], [Span.Overlaps], [Span.During],
+// [Span.Equals] and, for the common question, [Span.Intersects].
+//
 // The GEDCOM encoding of the same model lives here as well, so the GLX
 // grammar is never re-implemented by a converter: [FromGEDCOM] turns a
 // GEDCOM DATE payload (calendar escape, any tolerated spelling) into the

--- a/go-glx/glxdate/span.go
+++ b/go-glx/glxdate/span.go
@@ -1,0 +1,233 @@
+// Copyright 2025 Oracynth, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package glxdate
+
+import "math"
+
+// Span is the inclusive run of days a [Date] denotes. It lets a caller ask
+// how two dates relate in time without re-deriving the qualifier and
+// precision rules at every call site. Build one with [Date.Span].
+//
+// A date maps to its span as follows:
+//
+//   - A simple date covers its written precision: "1900" is the whole year,
+//     "1900-03" the whole month, "1900-03-15" the single day. ABT, EST, CAL
+//     and INT do not widen a date; they denote the same span as the bare
+//     date.
+//   - BEF and AFT exclude the named date and are open on the far side:
+//     "AFT 1900" runs from 1901-01-01 onward, "AFT 1900-03-15" from
+//     1900-03-16, "BEF 1900-03" up to 1900-02-28. This is the reading the
+//     analyze command already applies to relationship windows and death
+//     years. The step to the neighbouring day follows the date's own
+//     calendar, so "JULIAN AFT 1900-02-28" starts on the Julian leap day
+//     1900-02-29 while the Gregorian "AFT 1900-02-28" starts on March 1,
+//     and 1 BCE is followed directly by 1 CE.
+//   - FROM…TO and BET…AND include both endpoints. "FROM 1870" is open at the
+//     end and "TO 1860" is open at the start.
+//   - A side whose year cannot be determined (free text, an empty string, a
+//     range endpoint with no year) is unbounded. A range whose end precedes
+//     its start spans all time rather than nothing, so a date the library
+//     cannot interpret is never silently dropped from a comparison.
+//   - No calendar conversion is performed: a Julian and a Gregorian date are
+//     compared on the same number line, as everywhere else in the library.
+//     Hebrew and French Republican dates keep their month names raw, so
+//     they span their whole year.
+//
+// The relations are Allen's interval algebra reduced to what inclusive days
+// need: [Span.Precedes], [Span.Overlaps], [Span.During] and [Span.Equals].
+// For any two spans X and Y exactly one of X.Precedes(Y), Y.Precedes(X),
+// X.Overlaps(Y), Y.Overlaps(X), X.During(Y), Y.During(X) and X.Equals(Y)
+// holds. Allen's "meets" has no place on inclusive days: two spans that
+// touch on a shared day overlap, and two on adjacent days with nothing
+// shared precede one another. Allen's "starts" and "finishes" fold into
+// During. [Span.Intersects] answers the question most callers have, whether
+// two spans share any day at all.
+type Span struct {
+	lo, hi int
+}
+
+// allTime is the span of every day, used for a date that cannot be placed.
+var allTime = Span{lo: math.MinInt, hi: math.MaxInt}
+
+// Span returns the inclusive run of days the date denotes; see [Span].
+func (d Date) Span() Span {
+	if d.IsRange() {
+		return d.rangeSpan()
+	}
+	if d.Year() == 0 {
+		return allTime
+	}
+	first, last := d.pointBounds()
+	switch d.Qualifier() {
+	case QualifierBefore:
+		return Span{lo: math.MinInt, hi: first.prev(d.Calendar()).key()}
+	case QualifierAfter:
+		return Span{lo: last.next(d.Calendar()).key(), hi: math.MaxInt}
+	default:
+		return Span{lo: first.key(), hi: last.key()}
+	}
+}
+
+// rangeSpan maps a range to its span. Start and End return the zero Date
+// for an open side, so both open forms and endpoints without a year fall
+// out of the same year check.
+func (d Date) rangeSpan() Span {
+	s := allTime
+	if start := d.Start(); start.Year() != 0 {
+		first, _ := start.pointBounds()
+		s.lo = first.key()
+	}
+	if end := d.End(); end.Year() != 0 {
+		_, last := end.pointBounds()
+		s.hi = last.key()
+	}
+	if s.lo > s.hi {
+		return allTime
+	}
+
+	return s
+}
+
+// pointBounds returns the first and last day of a point date at its
+// written precision. Month and day take part only when the parser resolved
+// them exactly, which it does for Gregorian and Julian bodies.
+func (d Date) pointBounds() (civilDay, civilDay) {
+	year := d.Year()
+	month, ok := d.Month()
+	if !ok {
+		return civilDay{year, 1, 1}, civilDay{year, 12, 31}
+	}
+	day, ok := d.Day()
+	if !ok {
+		return civilDay{year, month, 1}, civilDay{year, month, daysIn(d.Calendar(), year, month)}
+	}
+
+	return civilDay{year, month, day}, civilDay{year, month, day}
+}
+
+// civilDay is a calendar day with a signed year (negative for BCE).
+type civilDay struct {
+	year, month, day int
+}
+
+// key orders days on one number line. Month and day contribute less than
+// 10000, so negative BCE years keep their order too: 45 BCE sorts before
+// 44 BCE, and every day of 44 BCE before 1 CE.
+func (c civilDay) key() int {
+	return c.year*10000 + c.month*100 + c.day
+}
+
+// next returns the following day in the given calendar.
+func (c civilDay) next(cal Calendar) civilDay {
+	if c.day < daysIn(cal, c.year, c.month) {
+		c.day++
+
+		return c
+	}
+	c.day = 1
+	if c.month < 12 {
+		c.month++
+
+		return c
+	}
+	c.month = 1
+	c.year++
+	if c.year == 0 {
+		c.year = 1 // 1 BCE is followed by 1 CE.
+	}
+
+	return c
+}
+
+// prev returns the preceding day in the given calendar.
+func (c civilDay) prev(cal Calendar) civilDay {
+	if c.day > 1 {
+		c.day--
+
+		return c
+	}
+	if c.month > 1 {
+		c.month--
+	} else {
+		c.month = 12
+		c.year--
+		if c.year == 0 {
+			c.year = -1 // 1 CE is preceded by 1 BCE.
+		}
+	}
+	c.day = daysIn(cal, c.year, c.month)
+
+	return c
+}
+
+// daysIn returns the length of a month. Only the Gregorian and Julian
+// calendars expose exact months, and they differ in leap years alone.
+func daysIn(cal Calendar, year, month int) int {
+	switch month {
+	case 4, 6, 9, 11:
+		return 30
+	case 2:
+		if isLeapYear(cal, year) {
+			return 29
+		}
+
+		return 28
+	default:
+		return 31
+	}
+}
+
+// isLeapYear applies the calendar's leap rule to a signed year. BCE years
+// are shifted to astronomical numbering first, in which 1 BCE is year 0,
+// so the four-year cycle continues unbroken across the era boundary.
+func isLeapYear(cal Calendar, year int) bool {
+	if year < 0 {
+		year++
+	}
+	if cal == CalendarJulian {
+		return year%4 == 0
+	}
+
+	return year%4 == 0 && (year%100 != 0 || year%400 == 0)
+}
+
+// Precedes reports whether s ends before o begins, sharing no day.
+func (s Span) Precedes(o Span) bool {
+	return s.hi < o.lo
+}
+
+// Overlaps reports whether s begins before o, shares at least one day with
+// it, and ends before it does. This is Allen's strict partial overlap; use
+// [Span.Intersects] to ask whether two spans share any day.
+func (s Span) Overlaps(o Span) bool {
+	return s.lo < o.lo && o.lo <= s.hi && s.hi < o.hi
+}
+
+// During reports whether every day of s lies within o and o is the larger
+// of the two. It covers Allen's starts, during and finishes.
+func (s Span) During(o Span) bool {
+	return o.lo <= s.lo && s.hi <= o.hi && s != o
+}
+
+// Equals reports whether the two spans cover exactly the same days.
+func (s Span) Equals(o Span) bool {
+	return s == o
+}
+
+// Intersects reports whether the two spans share at least one day, which is
+// to say neither precedes the other.
+func (s Span) Intersects(o Span) bool {
+	return !s.Precedes(o) && !o.Precedes(s)
+}

--- a/go-glx/glxdate/span_test.go
+++ b/go-glx/glxdate/span_test.go
@@ -1,0 +1,255 @@
+// Copyright 2025 Oracynth, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package glxdate
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// relationOf names the one relation that holds between a and b, failing the
+// test unless exactly one of the seven does.
+func relationOf(t *testing.T, a, b Span) string {
+	t.Helper()
+	held := []string{}
+	for name, holds := range map[string]bool{
+		"precedes":     a.Precedes(b),
+		"precededBy":   b.Precedes(a),
+		"overlaps":     a.Overlaps(b),
+		"overlappedBy": b.Overlaps(a),
+		"during":       a.During(b),
+		"contains":     b.During(a),
+		"equals":       a.Equals(b),
+	} {
+		if holds {
+			held = append(held, name)
+		}
+	}
+	require.Len(t, held, 1, "exactly one relation must hold between %+v and %+v, got %v", a, b, held)
+
+	return held[0]
+}
+
+// spanOf parses best-effort: an invalid date still yields the components
+// the parser could determine, which is what Span is defined over.
+func spanOf(s string) Span {
+	d, _ := Parse(s) //nolint:errcheck // best-effort components are the point of the test
+
+	return d.Span()
+}
+
+func TestSpan_Relations(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want string
+	}{
+		// Simple dates at their written precision.
+		{"1851", "1852", "precedes"},
+		{"1852", "1851", "precededBy"},
+		{"1851", "1851", "equals"},
+		{"1851-03", "1851", "during"},
+		{"1851", "1851-03", "contains"},
+		{"1851-03-15", "1851-03", "during"},
+		{"1851-03-15", "1851-03-16", "precedes"},
+		{"1851-03", "1851-04", "precedes"},
+
+		// Qualifiers other than BEF and AFT do not widen a date.
+		{"ABT 1851", "1851", "equals"},
+		{"EST 1851", "1851", "equals"},
+		{"CAL 1851", "1851", "equals"},
+		{"INT 1851", "1851", "equals"},
+		{"ABT 1851", "1852", "precedes"},
+
+		// Spellings and calendars.
+		{"15 March 1851", "1851-03-15", "equals"},
+		{"JULIAN 1851", "1851", "equals"},
+		{"HEBREW 15 TSH 5765", "5765", "equals"},
+
+		// Closed ranges include both endpoints; FROM…TO and BET…AND agree.
+		{"FROM 1870 TO 1920", "1870", "contains"},
+		{"FROM 1870 TO 1920", "1920", "contains"},
+		{"FROM 1870 TO 1920", "1921", "precedes"},
+		{"BET 1870 AND 1920", "FROM 1870 TO 1920", "equals"},
+		{"BET 1840 AND 1855", "FROM 1850 TO 1860", "overlaps"},
+		{"FROM 1850 TO 1860", "BET 1840 AND 1855", "overlappedBy"},
+		{"FROM 298 TO 298", "298", "equals"},
+
+		// Open ranges.
+		{"FROM 1870", "1869", "precededBy"},
+		{"FROM 1870", "1870", "contains"},
+		{"TO 1860", "1861", "precedes"},
+		{"TO 1860", "1860", "contains"},
+		{"FROM 1870", "TO 1869", "precededBy"},
+		{"FROM 1870", "TO 1870", "overlappedBy"},
+		{"FROM 1870", "FROM 1880", "contains"},
+		{"TO 1860", "TO 1850", "contains"},
+
+		// BEF and AFT exclude the named year and are open on the far side.
+		{"AFT 1900", "1900", "precededBy"},
+		{"AFT 1900", "1901", "contains"},
+		{"AFT 1900", "1950", "contains"},
+		{"BEF 1900", "1900", "precedes"},
+		{"BEF 1900", "1899", "contains"},
+		{"BEF 1900", "1880", "contains"},
+		{"AFT 1900", "AFT 1950", "contains"},
+		{"BEF 1900", "BEF 1850", "contains"},
+		{"BEF 1950", "AFT 1900", "overlaps"},
+		{"AFT 1900", "BEF 1950", "overlappedBy"},
+		{"AFT 1950", "BEF 1900", "precededBy"},
+		{"AFT 1900", "BEF 1901", "precededBy"},
+		{"AFT 1900", "BEF 1902", "overlappedBy"},
+
+		// The excluded unit is the written precision, not the whole year.
+		{"AFT 1900-03-15", "1900-03-15", "precededBy"},
+		{"AFT 1900-03-15", "1900-03-16", "contains"},
+		{"AFT 1900-03-15", "1900-03", "overlappedBy"},
+		{"AFT 1900-01-01", "1900", "overlappedBy"},
+		{"AFT 1900-03", "1900-03-31", "precededBy"},
+		{"AFT 1900-03", "1900-04-01", "contains"},
+		{"AFT 1900-12", "1900", "precededBy"},
+		{"AFT 1900-12", "1901", "contains"},
+		{"BEF 1900-03", "1900-03-01", "precedes"},
+		{"BEF 1900-03", "1900-02", "contains"},
+		{"BEF 1900-03", "1900-02-28", "contains"},
+		{"BEF 1900-03-15", "1900-03-15", "precedes"},
+		{"BEF 1900-03-15", "1900-03-14", "contains"},
+		{"BEF 1900-01-01", "1900", "precedes"},
+		{"BEF 1900-01-01", "1899", "contains"},
+
+		// BEF and AFT against ranges.
+		{"AFT 1900", "TO 1900", "precededBy"},
+		{"AFT 1900", "TO 1901", "overlappedBy"},
+		{"BEF 1900", "FROM 1900", "precedes"},
+		{"BEF 1900", "FROM 1899", "overlaps"},
+		{"AFT 1900", "FROM 1900 TO 1900", "precededBy"},
+		{"AFT 1900", "BET 1900 AND 1901", "overlappedBy"},
+
+		// Calendar prefixes and tolerated spellings keep the qualifier.
+		{"JULIAN AFT 1900", "1950", "contains"},
+		{"JULIAN AFT 1900", "1900", "precededBy"},
+		{"JULIAN BEF 1900", "1900", "precedes"},
+		{"bef 1900", "1900", "precedes"},
+		{"AFTER 1900", "1900", "precededBy"},
+		{"before 1900", "1900", "precedes"},
+
+		// Unwidened qualifiers meet BEF and AFT exactly at the edge.
+		{"AFT 1900", "ABT 1900", "precededBy"},
+		{"BEF 1901", "ABT 1900", "contains"},
+
+		// Shifted bounds land on real days, so facing BEF and AFT never meet
+		// on a day that does not exist.
+		{"AFT 1900-04-30", "BEF 1900-05-01", "precededBy"},
+		{"AFT 1900-03-31", "1900-04-01", "contains"},
+		{"AFT 1900-02-28", "1900-02-29", "precededBy"},
+		{"AFT 1900-02-28", "1900-03-01", "contains"},
+		{"AFT 1904-02-28", "1904-02-29", "contains"},
+		{"JULIAN AFT 1900-02-28", "1900-02-29", "contains"},
+		{"BEF 1900-03", "1900-02-28", "contains"},
+		{"BEF 1900-03", "1900-02-29", "precedes"},
+		{"BEF 1904-03", "1904-02-29", "contains"},
+
+		// BCE years keep their order across the era boundary, and the step
+		// from BEF or AFT skips the year 0 that neither calendar has.
+		{"0045 BCE", "0044 BCE", "precedes"},
+		{"0044-12-31 BCE", "0044-01-01 BCE", "precededBy"},
+		{"0001 BCE", "0001", "precedes"},
+		{"AFT 0001 BCE", "0001", "contains"},
+		{"AFT 0001 BCE", "BEF 0001", "precededBy"},
+		{"BEF 0001", "0001 BCE", "contains"},
+
+		// Dates that cannot be placed span all time.
+		{"", "1900", "contains"},
+		{"", "", "equals"},
+		{"spring", "AFT 1900", "contains"},
+		{"FROM 1850 TO spring", "1900", "contains"},
+		{"FROM 1850 TO spring", "1849", "precededBy"},
+		{"FROM spring TO 1850", "1800", "contains"},
+		{"FROM spring TO 1850", "1851", "precedes"},
+		{"FROM 1920 TO 1870", "1900", "contains"},
+		{"BET 1920 AND 1870", "", "equals"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.a+" vs "+tt.b, func(t *testing.T) {
+			a, b := spanOf(tt.a), spanOf(tt.b)
+			got := relationOf(t, a, b)
+			require.Equal(t, tt.want, got)
+
+			wantIntersects := got != "precedes" && got != "precededBy"
+			require.Equal(t, wantIntersects, a.Intersects(b))
+			require.Equal(t, wantIntersects, b.Intersects(a))
+		})
+	}
+}
+
+func TestSpan_Bounds(t *testing.T) {
+	tests := []struct {
+		date string
+		want Span
+	}{
+		{"1900", Span{lo: 19000101, hi: 19001231}},
+		{"1900-03", Span{lo: 19000301, hi: 19000331}},
+		{"1900-02", Span{lo: 19000201, hi: 19000228}},
+		{"1904-02", Span{lo: 19040201, hi: 19040229}},
+		{"2000-02", Span{lo: 20000201, hi: 20000229}},
+		{"JULIAN 1900-02", Span{lo: 19000201, hi: 19000229}},
+		{"1900-03-15", Span{lo: 19000315, hi: 19000315}},
+		{"AFT 1900", Span{lo: 19010101, hi: math.MaxInt}},
+		{"AFT 1900-12", Span{lo: 19010101, hi: math.MaxInt}},
+		{"AFT 1900-12-31", Span{lo: 19010101, hi: math.MaxInt}},
+		{"AFT 1900-02-28", Span{lo: 19000301, hi: math.MaxInt}},
+		{"JULIAN AFT 1900-02-28", Span{lo: 19000229, hi: math.MaxInt}},
+		{"BEF 1900", Span{lo: math.MinInt, hi: 18991231}},
+		{"BEF 1900-01", Span{lo: math.MinInt, hi: 18991231}},
+		{"BEF 1900-01-01", Span{lo: math.MinInt, hi: 18991231}},
+		{"BEF 1900-03-01", Span{lo: math.MinInt, hi: 19000228}},
+		{"FROM 1870 TO 1920", Span{lo: 18700101, hi: 19201231}},
+		{"FROM 1870", Span{lo: 18700101, hi: math.MaxInt}},
+		{"TO 1860", Span{lo: math.MinInt, hi: 18601231}},
+		{"0044-03-15 BCE", Span{lo: -440000 + 315, hi: -440000 + 315}},
+		{"AFT 0001 BCE", Span{lo: 10101, hi: math.MaxInt}},
+		{"BEF 0001", Span{lo: math.MinInt, hi: -10000 + 1231}},
+		{"", allTime},
+		{"FROM 1920 TO 1870", allTime},
+	}
+	for _, tt := range tests {
+		t.Run(tt.date, func(t *testing.T) {
+			require.Equal(t, tt.want, spanOf(tt.date))
+		})
+	}
+}
+
+// TestSpan_RelationsAreExclusive checks the algebra itself on every pair of
+// small spans, including open sides: exactly one relation holds each time,
+// and Intersects agrees with the relation that does.
+func TestSpan_RelationsAreExclusive(t *testing.T) {
+	bounds := []int{math.MinInt, 0, 1, 2, 3, math.MaxInt}
+	var spans []Span
+	for _, lo := range bounds {
+		for _, hi := range bounds {
+			if lo <= hi {
+				spans = append(spans, Span{lo: lo, hi: hi})
+			}
+		}
+	}
+	for _, a := range spans {
+		for _, b := range spans {
+			rel := relationOf(t, a, b)
+			shareDay := a.lo <= b.hi && b.lo <= a.hi
+			require.Equal(t, shareDay, a.Intersects(b), "%+v vs %+v (%s)", a, b, rel)
+		}
+	}
+}


### PR DESCRIPTION
## What and why

`glxdate` can parse a date into its components, but nothing in the library places those components on a number line. So every command that needs to compare two dates writes its own year arithmetic: `extractRelationshipBoundaryYear` and `wasActiveInYear` in the suggestions code, the `--before`/`--after` flags in `query` and `cluster`, and now a private `spanOf` in `glx analyze` for the temporal conflict check in #1227. Review of that PR showed how easily a hand-rolled span goes wrong (`BEF`/`AFT` collapsed to the named year, an inverted range overlapping nothing).

This PR adds `Date.Span()` and a `Span` type to `glxdate` so that step lives once, next to the parser, with the rules written down in one place:

- A simple date covers its written precision: `1900` is the year, `1900-03` the month, `1900-03-15` the day. `ABT`, `EST`, `CAL` and `INT` do not widen it.
- `BEF` and `AFT` exclude the named date and are open on the far side: `AFT 1900` starts 1901-01-01, `AFT 1900-03-15` starts 1900-03-16, `BEF 1900-03` ends 1900-02-28. This is the reading `extractRelationshipBoundaryYear` and `deathYearUpperBound` already apply, and what the strict `--before`/`--after` flags do.
- `FROM…TO` and `BET…AND` include both endpoints; `FROM X` and `TO X` are unbounded on the open side.
- A side with no usable year is unbounded, and a range whose end precedes its start spans all time, so a date the library cannot interpret is never silently dropped from a comparison.
- No calendar conversion, same as the rest of the library.

The relations are Allen's interval algebra cut down to what inclusive days need: `Precedes`, `Overlaps`, `During`, `Equals`. For any two spans exactly one of the seven directed relations holds. Allen's "meets" has no place on inclusive days (touching on a shared day is overlap, adjacent days with nothing shared is precedes), and "starts"/"finishes" fold into `During`. `Intersects` answers the question most callers actually have, whether two spans share any day.

Two design points worth a look:

- **Bounds are real calendar days.** An earlier draft stepped the integer key by one (`AFT 1900` = key of 1900-12-31 plus one). That works against plain dates but lets `AFT 1900` and `BEF 1901` "overlap" on keys no day occupies. Stepping through the date's own calendar fixes it. That is the one piece of calendar arithmetic in the file (Gregorian or Julian leap rule, and 1 BCE followed by 1 CE); it is not calendar conversion.
- **No dependency.** The Go interval libraries are either `time.Time` based or unmaintained, and the date-to-span mapping is the GLX-specific part anyway. The algebra itself is a few lines.

**Intended use.** I would like to use this in #1227, replacing the analyze command's private `spanOf`/`overlappingValues` with `a.Span().Intersects(b.Span())`, and later where the suggestions code does the same thing at year granularity. Opening it separately so the shape can be discussed on its own before #1227 depends on it. Nothing calls it yet.

## Related issues

Related: #1227, #1213. None closed by this PR.

## Review focus

- API shape: four predicates plus `Intersects`, bounds unexported.
- The `BEF`/`AFT` rule. The spec's Date Format Standard currently says nothing about whether the named date is included; GEDCOM 5.5.1 reads it the way this does, GEDCOM 7.0 reads `AFT x` as "no earlier than x". If this lands, a sentence in `specification/2-core-concepts.md` should probably follow.
- Whether an inverted range should span all time (as here) or be normalised by swapping the endpoints.

## Testing

`go test ./go-glx/...` is green. New tests in `span_test.go`:

- a table of about a hundred date pairs asserting which single relation holds and that `Intersects` agrees, covering precision, qualifiers, tolerated spellings, calendar prefixes, open and closed ranges, BCE, and unplaceable dates;
- exact bounds for each precision, leap years in both calendars, and the year-0 skip;
- an exhaustive check over every pair of small spans, open sides included, that the seven relations are mutually exclusive and total.

## Breaking changes

None. Additive API.
